### PR TITLE
Adds a warm-start mechanism to PyOperon

### DIFF
--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -420,7 +420,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
             return op.InfixFormatter.Format(model, names_map, precision)
 
 
-    def fit(self, X, y):
+    def fit(self, X, y, warm_start=False):
         """A reference implementation of a fitting function.
 
         Parameters
@@ -430,6 +430,8 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         y : array-like, shape (n_samples,) or (n_samples, n_outputs)
             The target values (class labels in classification, real numbers in
             regression).
+        warm_start : bool, when set to True reuse the individuals of the 
+            previous call to `fit` to continue training
 
         Returns
         -------
@@ -547,7 +549,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
                  op.NSGA2Algorithm(config, problem, tree_initializer, coeff_initializer, generator, reinserter, sorter)
         rng    = op.RandomGenerator(np.uint64(config.Seed))
 
-        gp.Run(rng, None, self.n_threads)
+        gp.Run(rng, None, self.n_threads, warm_start)
 
 
         def get_solution_stats(solution):

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -23,8 +23,8 @@ void InitAlgorithm(nb::module_ &m)
 
     nb::class_<Operon::GeneticProgrammingAlgorithm, Operon::GeneticAlgorithmBase>(m, "GeneticProgrammingAlgorithm")
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*>())
-        .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t>(&Operon::GeneticProgrammingAlgorithm::Run),
-                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0)
+        .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t, bool>(&Operon::GeneticProgrammingAlgorithm::Run),
+                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
         .def("Reset", &Operon::GeneticProgrammingAlgorithm::Reset, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("BestModel", [](Operon::GeneticProgrammingAlgorithm const& self) {
                 auto minElem = std::min_element(self.Parents().begin(), self.Parents().end(), [&](auto const& a, auto const& b) { return a[0] < b[0]; });


### PR DESCRIPTION
This pull request adds support for warm start training in the PyOperon scikit-learn bindings, allowing users to call .fit() incrementally. This brings PyOperon in line with other modern frameworks like PySR and Scikit-learn, which already support incremental updates.

By enabling warm starts, users can continue training from a previously fitted model. It also allows users to circumvent the constraints of the callback method  #18.

This feature is particularly important for research scenarios where training without batching can take several days. With warm start support and horizontal batching, experiments that previously took up to 20 days can now be completed far more efficiently. A recent paper, ["A Survey on Batch Training in Genetic Programming", by Liah Rosenfeld and Leonardo Vanneschi](https://link.springer.com/article/10.1007/s10710-024-09501-6), highlights the potential of batching strategies for improving the scalability of genetic programming.

The underlying support for warm starts was added in a corresponding pull request to the Operon core library, and this PR ensures that the Python bindings can take full advantage of that functionality.

This also addresses a feature request in PyOperon #22.