### PR TITLE
fix(bindings): add keep_alive to prevent use-after-free segfault on inline temporaries

### DIFF
--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -813,7 +813,6 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         aik_eval = op.AkaikeInformationCriterionEvaluator(problem, dtable)
 
         # Fitness evaluator(s)
-        # Keep references to extend lifetimes of C++ objects held by pointer
         evaluators = []
         for obj in objectives:
             eval_ = self._init_evaluator(obj, problem, dtable, uncertainty)
@@ -841,12 +840,9 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         )
 
         mut = op.MultiMutation()
-        # Keep references to extend lifetimes (MultiMutation stores pointers)
-        mut_list = []
         for k, v in mutation.items():
             m = self._init_mutation(k, inputs, pset, creator, coeff_initializer)
             mut.Add(m, v)
-            mut_list.append(m)
 
         coeff_optimizer = op.CoefficientOptimizer(optimizer)
         generator = self._init_generator(

--- a/source/evaluator.cpp
+++ b/source/evaluator.cpp
@@ -205,10 +205,12 @@ void InitEval(nb::module_ &m)
         .def_prop_ro("JacobianEvaluations", [](TEvaluatorBase& self) { return self.JacobianEvaluations.load(); });
 
     nb::class_<TEvaluator, TEvaluatorBase>(m, "Evaluator")
-        .def(nb::init<Operon::Problem const*, TDispatch const*, Operon::ErrorMetric, bool>());
+        .def(nb::init<Operon::Problem const*, TDispatch const*, Operon::ErrorMetric, bool>(),
+            nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>());
 
     nb::class_<Operon::UserDefinedEvaluator, TEvaluatorBase>(m, "UserDefinedEvaluator")
-        .def(nb::init<Operon::Problem const*, std::function<typename TEvaluatorBase::ReturnType(Operon::RandomGenerator*, Operon::Individual const&)> const&>())
+        .def(nb::init<Operon::Problem const*, std::function<typename TEvaluatorBase::ReturnType(Operon::RandomGenerator*, Operon::Individual const&)> const&>(),
+            nb::keep_alive<1, 2>())
         .def("__call__", [](TEvaluatorBase const& self, Operon::RandomGenerator& rng, Operon::Individual& ind) {
             nb::gil_scoped_release release;
             auto result = self(rng, ind, {});
@@ -216,17 +218,17 @@ void InitEval(nb::module_ &m)
         });
 
     nb::class_<Operon::LengthEvaluator, TEvaluatorBase>(m, "LengthEvaluator")
-        .def(nb::init<Operon::Problem const*>());
+        .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>());
 
     nb::class_<Operon::ShapeEvaluator, TEvaluatorBase>(m, "ShapeEvaluator")
-        .def(nb::init<Operon::Problem const*>());
+        .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>());
 
     nb::class_<Operon::DiversityEvaluator, TEvaluatorBase>(m, "DiversityEvaluator")
-        .def(nb::init<Operon::Problem const*>());
+        .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>());
 
     nb::class_<Operon::MultiEvaluator, TEvaluatorBase>(m, "MultiEvaluator")
-        .def(nb::init<Operon::Problem const*>())
-        .def("Add", &Operon::MultiEvaluator::Add);
+        .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>())
+        .def("Add", &Operon::MultiEvaluator::Add, nb::keep_alive<1, 2>());
 
     nb::enum_<Operon::AggregateEvaluator::AggregateType>(m, "AggregateType")
         .value("Min", Operon::AggregateEvaluator::AggregateType::Min)
@@ -237,28 +239,29 @@ void InitEval(nb::module_ &m)
         .value("Sum", Operon::AggregateEvaluator::AggregateType::Sum);
 
     nb::class_<Operon::AggregateEvaluator, TEvaluatorBase>(m, "AggregateEvaluator")
-        .def(nb::init<TEvaluatorBase const*>())
+        .def(nb::init<TEvaluatorBase const*>(), nb::keep_alive<1, 2>())
         .def_prop_rw("AggregateType", &Operon::AggregateEvaluator::GetAggregateType, &Operon::AggregateEvaluator::SetAggregateType);
 
     nb::class_<detail::MDLEvaluator>(m, "MinimumDescriptionLengthEvaluator")
-        .def(nb::init<Operon::Problem const&, TDispatch const&, std::string const&>())
+        .def(nb::init<Operon::Problem const&, TDispatch const&, std::string const&>(),
+            nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def("__call__", [](detail::MDLEvaluator const& self, Operon::RandomGenerator& rng, Operon::Individual const& ind) {
             return (*self.Get())(rng, ind);
         })
         .def_prop_rw("Sigma", nullptr /*get*/ , &detail::MDLEvaluator::SetSigma /*set*/);
 
     nb::class_<TBICEvaluator, TEvaluator>(m, "BayesianInformationCriterionEvaluator")
-        .def(nb::init<Operon::Problem const*, TDispatch const*>());
+        .def(nb::init<Operon::Problem const*, TDispatch const*>(), nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>());
 
     nb::class_<TAIKEvaluator, TEvaluator>(m, "AkaikeInformationCriterionEvaluator")
-        .def(nb::init<Operon::Problem const*, TDispatch const*>());
+        .def(nb::init<Operon::Problem const*, TDispatch const*>(), nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>());
 
     nb::class_<TGaussEvaluator, TEvaluator>(m, "GaussianLikelihoodEvaluator")
-        .def(nb::init<Operon::Problem const*, TDispatch const*>())
+        .def(nb::init<Operon::Problem const*, TDispatch const*>(), nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def_prop_rw("Sigma", &TGaussEvaluator::Sigma , &TGaussEvaluator::SetSigma /*set*/);;
 
     nb::class_<TPoissonEvaluator, TEvaluator>(m, "PoissonLikelihoodEvaluator")
-        .def(nb::init<Operon::Problem const*, TDispatch const*>())
+        .def(nb::init<Operon::Problem const*, TDispatch const*>(), nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def_prop_rw("Sigma", [](TPoissonEvaluator const& self) {
             auto sigma = self.Sigma();
             return std::vector<Operon::Scalar>(sigma.begin(), sigma.end());

--- a/source/mutation.cpp
+++ b/source/mutation.cpp
@@ -77,10 +77,10 @@ void InitMutation(nb::module_ &m)
     nb::class_<Operon::MultiMutation, Operon::MutatorBase>(m, "MultiMutation")
         .def(nb::init<>())
         .def("__call__", &Operon::MultiMutation::operator())
-        .def("Add", &Operon::MultiMutation::Add)
+        .def("Add", &Operon::MultiMutation::Add, nb::keep_alive<1, 2>())
         .def("Add", [](Operon::MultiMutation& self, Operon::MutatorBase const& mut, double prob) {
             self.Add(&mut, prob);
-        })
+        }, nb::keep_alive<1, 2>())
         .def_prop_ro("Count", &Operon::MultiMutation::Count);
 
 }

--- a/source/optimizer.cpp
+++ b/source/optimizer.cpp
@@ -78,7 +78,7 @@ void InitOptimizer(nb::module_ &m)
     nb::class_<Operon::CoefficientOptimizer>(m, "CoefficientOptimizer")
         .def("__init__", [](Operon::CoefficientOptimizer* op, detail::Optimizer const& opt) {
             new (op) Operon::CoefficientOptimizer(opt.Get());
-        })
+        }, nb::keep_alive<1, 2>())
         .def("__call__", &Operon::CoefficientOptimizer::operator());
 
     nb::class_<Operon::OptimizerSummary>(m, "OptimizerSummary")
@@ -100,6 +100,8 @@ void InitOptimizer(nb::module_ &m)
             , nb::arg("problem")
             , nb::arg("max_iter") = 10
             , nb::arg("batch_size") = TDispatch::BatchSize<Operon::Scalar>
+            , nb::keep_alive<1, 2>()
+            , nb::keep_alive<1, 3>()
         );
 
     nb::class_<detail::LBFGSOptimizer, detail::Optimizer>(m, "LBFGSOptimizer")
@@ -109,6 +111,8 @@ void InitOptimizer(nb::module_ &m)
             , nb::arg("likelihood") = "gaussian"
             , nb::arg("max_iter") = 10
             , nb::arg("batch_size") = TDispatch::BatchSize<Operon::Scalar>
+            , nb::keep_alive<1, 2>()
+            , nb::keep_alive<1, 3>()
         );
 
     nb::class_<detail::SGDOptimizer, detail::Optimizer>(m, "SGDOptimizer")
@@ -119,6 +123,8 @@ void InitOptimizer(nb::module_ &m)
             , nb::arg("likelihood") = "gaussian"
             , nb::arg("max_iter") = 10
             , nb::arg("batch_size") = TDispatch::BatchSize<Operon::Scalar>
+            , nb::keep_alive<1, 2>()
+            , nb::keep_alive<1, 3>()
         );
 
     // SGD update rules class definitions


### PR DESCRIPTION
## Summary

Fixes #59 (partially — see that issue for the remaining, not-yet-reproduced constructors).

Several composite/aggregate classes in the bindings store **non-owning raw pointers** to sub-objects passed to their constructors or `.Add()` methods:

- `MultiMutation.Add`, `MultiEvaluator.Add`
- `CoefficientOptimizer`'s constructor
- `LMOptimizer`/`LBFGSOptimizer`/`SGDOptimizer` (store both `dtable` and `problem`)
- `Evaluator`, `UserDefinedEvaluator`, `LengthEvaluator`, `ShapeEvaluator`, `DiversityEvaluator`, `MultiEvaluator`, `AggregateEvaluator`, `MinimumDescriptionLengthEvaluator`, `BayesianInformationCriterionEvaluator`, `AkaikeInformationCriterionEvaluator`, `GaussianLikelihoodEvaluator`, `PoissonLikelihoodEvaluator`

None of the bindings had a `nb::keep_alive<>()` policy. The underlying C++ classes are written assuming the caller's objects (typically C++ stack locals) outlive the composite object — true for normal C++ code, but not true in Python when the argument is an inline temporary with no other references. The temporary is garbage-collected as soon as the call returns, leaving a dangling pointer that segfaults later, whenever it's actually used (not at construction time — which makes this particularly nasty to debug).

## Reproduction

```python
mutation = Operon.MultiMutation()
mutation.Add(Operon.NormalOnePointMutation(), 1)  # temporary, no other reference
# ... build the rest of a GP setup ...
gp.Run(rng, callback, threads=1)  # segfaults here
```

I bisected this from a real crash down to the exact root cause (see #59 for the full writeup and reproduction script), confirming it independently for `MultiMutation.Add`, `CoefficientOptimizer`, and `LMOptimizer`'s `dtable` argument — each one individually reproduced and fixed.

## Fix

Add `nb::keep_alive<1, N>()` to every affected binding, tying each stored sub-object's lifetime to the owning composite object's lifetime.

## Test plan

- [x] `nix build .#default` — builds clean
- [x] Original crash repro (`mutation.Add(Operon.NormalOnePointMutation(), 1)` + full GP run) — no longer segfaults
- [x] `Operon.CoefficientOptimizer(Operon.LMOptimizer(Operon.DispatchTable(), problem, max_iter=1))` (both temporaries) — no longer segfaults, runs to completion, correct results
- [x] Full `GeneticProgrammingAlgorithm.Run` with `UserDefinedEvaluator` + all-inline-temporary mutators/optimizer (the original crash was actually three compounded instances of this bug) — now completes cleanly, callback invoked as expected
- [x] Existing example scripts (`example/operon-bindings.py`, both `Evaluator`/`R2` and `UserDefinedEvaluator` variants) — still pass, correct results, no regression
- [x] `pyoperon.sklearn.SymbolicRegressor.fit`/`.score` end-to-end — still works