### PR TITLE
fix(bindings): include nanobind/stl/string.h for Dataset.VariableNames

### DIFF
--- a/include/pyoperon/pyoperon.hpp
+++ b/include/pyoperon/pyoperon.hpp
@@ -4,6 +4,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/function.h>
 

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileConb::rightText: Conb::right 2019-2021 Heal Research
+// SPDX-FileCopyrightText: Copyright 2019-2021 Heal Research
 
 #include "pyoperon/pyoperon.hpp"
 #include <operon/algorithms/gp.hpp>


### PR DESCRIPTION
## Summary

`Dataset.VariableNames`/`SetVariableNames` bind `std::vector<std::string>`, but the bindings only pulled in `nanobind/stl/vector.h` and not `nanobind/stl/string.h`. Without the string type caster, accessing `VariableNames` throws a `TypeError` — most visibly when a `Dataset` is constructed directly from an ndarray (no CSV header to derive names from), since that's the only path that reads `VariableNames` before anything else sets it.

Fixes #57

## Repro (before fix)

```python
import numpy as np
import pyoperon as Operon

A = np.asfortranarray(np.random.rand(20, 3).astype(np.float32))
ds = Operon.Dataset(A)
ds.VariableNames  # TypeError
```

## Fix

Add `#include <nanobind/stl/string.h>` to `include/pyoperon/pyoperon.hpp` (shared by all bindings, same place `vector.h` already lives).

Also fixed an unrelated cosmetic typo in `source/algorithm.cpp`'s copyright comment (`Conb::rightText: Conb::right` → `Copyright`), evidently mangled by a previous `py::`→`nb::` find-and-replace that matched the `py` inside `Copyright`.

## Test plan

- [x] Built via `cmake --build` in the nix devshell
- [x] Repro from #57 now returns `['X1', 'X2', 'X3']` instead of raising
- [x] `example/operon-bindings.py` (full GP run with progress callback, exercises the multithreaded evaluator path) still runs cleanly end-to-end