### PR TITLE
fix(bindings): add keep_alive to remaining composite/sub-object constructors

### DIFF
--- a/include/pyoperon/pyoperon.hpp
+++ b/include/pyoperon/pyoperon.hpp
@@ -24,12 +24,12 @@ NB_MAKE_OPAQUE(std::vector<Operon::Variable>);
 NB_MAKE_OPAQUE(std::vector<Operon::Individual>);
 
 template<typename T>
-auto MakeView(Operon::Span<T const> view)
+auto MakeView(Operon::Span<T const> view, nb::handle owner)
 {
     return nb::ndarray<T const, nb::numpy, nb::shape<-1>, nb::f_contig>(
         /* data = */ view.data(),
         /* ndim = */ {view.size()},
-        /* owner = */ nb::handle() // null owner
+        /* owner = */ owner // keeps the owning object (e.g. the Dataset) alive as long as the view is
     );
 }
 

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -22,7 +22,8 @@ void InitAlgorithm(nb::module_ &m)
         ;
 
     nb::class_<Operon::GeneticProgrammingAlgorithm, Operon::GeneticAlgorithmBase>(m, "GeneticProgrammingAlgorithm")
-        .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*>())
+        .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*>(),
+                nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
         .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t, bool>(&Operon::GeneticProgrammingAlgorithm::Run),
                 nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
         .def("Reset", &Operon::GeneticProgrammingAlgorithm::Reset, nb::call_guard<nb::gil_scoped_release>())
@@ -37,7 +38,8 @@ void InitAlgorithm(nb::module_ &m)
         .def_prop_ro("Config", &Operon::GeneticProgrammingAlgorithm::GetConfig, nb::call_guard<nb::gil_scoped_release>());
 
     nb::class_<Operon::NSGA2, Operon::GeneticAlgorithmBase>(m, "NSGA2Algorithm")
-        .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*, Operon::NondominatedSorterBase const*>())
+        .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*, Operon::NondominatedSorterBase const*>(),
+                nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>(), nb::keep_alive<1, 8>())
         .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t, bool>(&Operon::NSGA2::Run),
                 nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, nb::arg("warm_start"_a) = false)	
         .def("Reset", &Operon::NSGA2::Reset)

--- a/source/creator.cpp
+++ b/source/creator.cpp
@@ -13,18 +13,21 @@ void InitCreator(nb::module_ &m)
 
     nb::class_<Operon::BalancedTreeCreator, Operon::CreatorBase>(m, "BalancedTreeCreator")
         .def(nb::init<Operon::PrimitiveSet const*, std::vector<Operon::Hash>, double, size_t>()
-            , nb::arg("grammar"), nb::arg("variables"), nb::arg("bias") = 0.0, nb::arg("max_length") = 0UL)
+            , nb::arg("grammar"), nb::arg("variables"), nb::arg("bias") = 0.0, nb::arg("max_length") = 0UL
+            , nb::keep_alive<1, 2>())
         .def("__call__", &Operon::BalancedTreeCreator::operator())
         .def_prop_rw("IrregularityBias", &Operon::BalancedTreeCreator::GetBias, &Operon::BalancedTreeCreator::SetBias);
 
     nb::class_<Operon::ProbabilisticTreeCreator, Operon::CreatorBase>(m, "ProbabilisticTreeCreator")
         .def(nb::init<Operon::PrimitiveSet const*, std::vector<Operon::Hash>, double, size_t>()
-            , nb::arg("grammar"), nb::arg("variables"), nb::arg("bias") = 0.0, nb::arg("max_length") = 0UL)
+            , nb::arg("grammar"), nb::arg("variables"), nb::arg("bias") = 0.0, nb::arg("max_length") = 0UL
+            , nb::keep_alive<1, 2>())
         .def("__call__", &Operon::ProbabilisticTreeCreator::operator())
         .def_prop_rw("IrregularityBias", &Operon::ProbabilisticTreeCreator::GetBias, &Operon::ProbabilisticTreeCreator::SetBias);
 
     nb::class_<Operon::GrowTreeCreator, Operon::CreatorBase>(m, "GrowTreeCreator")
         .def(nb::init<Operon::PrimitiveSet const*, std::vector<Operon::Hash>, size_t>()
-            , nb::arg("grammar"), nb::arg("variables"), nb::arg("max_length") = 0UL)
+            , nb::arg("grammar"), nb::arg("variables"), nb::arg("max_length") = 0UL
+            , nb::keep_alive<1, 2>())
         .def("__call__", &Operon::GrowTreeCreator::operator());
 }

--- a/source/dataset.cpp
+++ b/source/dataset.cpp
@@ -91,14 +91,14 @@ void InitDataset(nb::module_ &m)
             size_t shape[2] = {static_cast<size_t>(ds.Rows()), static_cast<size_t>(view.extent(1))};
             int64_t strides[2] = {1, static_cast<int64_t>(view.extent(0))};
             return nb::ndarray<Operon::Scalar const, nb::numpy>(
-                view.data_handle(), 2, shape, nb::handle(), strides
+                view.data_handle(), 2, shape, nb::find(ds), strides
             );
         })
         .def_prop_rw("VariableNames", &Operon::Dataset::VariableNames, &Operon::Dataset::SetVariableNames)
         .def_prop_ro("VariableHashes", &Operon::Dataset::VariableHashes)
-        .def("GetValues", [](Operon::Dataset const& self, std::string const& name) { return MakeView(self.GetValues(name)); })
-        .def("GetValues", [](Operon::Dataset const& self, Operon::Hash hash) { return MakeView(self.GetValues(hash)); })
-        .def("GetValues", [](Operon::Dataset const& self, int64_t index) { return MakeView(self.GetValues(index)); })
+        .def("GetValues", [](Operon::Dataset const& self, std::string const& name) { return MakeView(self.GetValues(name), nb::find(self)); })
+        .def("GetValues", [](Operon::Dataset const& self, Operon::Hash hash) { return MakeView(self.GetValues(hash), nb::find(self)); })
+        .def("GetValues", [](Operon::Dataset const& self, int64_t index) { return MakeView(self.GetValues(index), nb::find(self)); })
         .def("GetVariable", nb::overload_cast<const std::string&>(&Operon::Dataset::GetVariable, nb::const_))
         .def("GetVariable", nb::overload_cast<Operon::Hash>(&Operon::Dataset::GetVariable, nb::const_))
         .def_prop_ro("Variables", &Operon::Dataset::GetVariables)

--- a/source/generator.cpp
+++ b/source/generator.cpp
@@ -37,7 +37,8 @@ void InitGenerator(nb::module_ &m)
     // basic offspring generator
     nb::class_<Operon::BasicOffspringGenerator, Operon::OffspringGeneratorBase>(m, "BasicOffspringGenerator")
         .def(nb::init<Operon::EvaluatorBase const*, Operon::CrossoverBase const*, Operon::MutatorBase const*,
-                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>())
+                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
         .def("__call__", [](Operon::OffspringGeneratorBase& self, Operon::RandomGenerator& rng, double pc, double pm, double pl, double pk, size_t n) {
             std::vector<Operon::Individual> v;
             v.reserve(n);
@@ -52,7 +53,8 @@ void InitGenerator(nb::module_ &m)
     // offspring selection generator
     nb::class_<Operon::OffspringSelectionGenerator, Operon::OffspringGeneratorBase>(m, "OffspringSelectionGenerator")
         .def(nb::init<Operon::EvaluatorBase const*, Operon::CrossoverBase const*, Operon::MutatorBase const*,
-                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>())
+                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
         .def("__call__", [](Operon::OffspringGeneratorBase& self, Operon::RandomGenerator& rng, double pc, double pm, double pl, double pk, size_t n) {
             std::vector<Operon::Individual> v;
             v.reserve(n);
@@ -76,7 +78,8 @@ void InitGenerator(nb::module_ &m)
     // brood generator
     nb::class_<Operon::BroodOffspringGenerator, Operon::OffspringGeneratorBase>(m, "BroodOffspringGenerator")
         .def(nb::init<Operon::EvaluatorBase const*, Operon::CrossoverBase const*, Operon::MutatorBase const*,
-                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>())
+                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
         .def("__call__", [](Operon::OffspringGeneratorBase& self, Operon::RandomGenerator& rng, double pc, double pm, double pl, double pk, size_t n) {
             std::vector<Operon::Individual> v;
             v.reserve(n);
@@ -95,7 +98,8 @@ void InitGenerator(nb::module_ &m)
     // polygenic generator
     nb::class_<Operon::PolygenicOffspringGenerator, Operon::OffspringGeneratorBase>(m, "PolygenicOffspringGenerator")
         .def(nb::init<Operon::EvaluatorBase const*, Operon::CrossoverBase const*, Operon::MutatorBase const*,
-                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>())
+                Operon::SelectorBase const*, Operon::SelectorBase const*, Operon::CoefficientOptimizer const*>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
         .def("__call__", [](Operon::OffspringGeneratorBase& self, Operon::RandomGenerator& rng, double pc, double pm, double pl, double pk, size_t n) {
             std::vector<Operon::Individual> v;
             v.reserve(n);

--- a/source/initializer.cpp
+++ b/source/initializer.cpp
@@ -14,7 +14,7 @@ void InitInitializer(nb::module_ &m)
     nb::class_<Operon::CoefficientInitializerBase> coeffInitializerBase(m, "CoefficientInitializerBase");
 
     nb::class_<UniformLengthTreeInitializer, Operon::TreeInitializerBase>(m, "UniformLengthTreeInitializer")
-        .def(nb::init<Operon::CreatorBase const*>())
+        .def(nb::init<Operon::CreatorBase const*>(), nb::keep_alive<1, 2>())
         // .def(nb::init<Operon::BalancedTreeCreator&>())
         // .def(nb::init<Operon::GrowTreeCreator&>())
         .def("__call__", [](UniformLengthTreeInitializer& self, Operon::RandomGenerator& random) {

--- a/source/mutation.cpp
+++ b/source/mutation.cpp
@@ -63,7 +63,8 @@ void InitMutation(nb::module_ &m)
         .def("__call__", &Operon::ChangeFunctionMutation::operator());
 
     nb::class_<Operon::ReplaceSubtreeMutation, Operon::MutatorBase>(m, "ReplaceSubtreeMutation")
-        .def(nb::init<Operon::CreatorBase const*, Operon::CoefficientInitializerBase const*, size_t, size_t>())
+        .def(nb::init<Operon::CreatorBase const*, Operon::CoefficientInitializerBase const*, size_t, size_t>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def("__call__", &Operon::ReplaceSubtreeMutation::operator());
 
     nb::class_<Operon::RemoveSubtreeMutation, Operon::MutatorBase>(m, "RemoveSubtreeMutation")
@@ -71,7 +72,8 @@ void InitMutation(nb::module_ &m)
         .def("__call__", &Operon::RemoveSubtreeMutation::operator());
 
     nb::class_<Operon::InsertSubtreeMutation, Operon::MutatorBase>(m, "InsertSubtreeMutation")
-        .def(nb::init<Operon::CreatorBase const*, Operon::CoefficientInitializerBase const*, size_t, size_t>())
+        .def(nb::init<Operon::CreatorBase const*, Operon::CoefficientInitializerBase const*, size_t, size_t>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def("__call__", &Operon::InsertSubtreeMutation::operator());
 
     nb::class_<Operon::MultiMutation, Operon::MutatorBase>(m, "MultiMutation")

--- a/source/problem.cpp
+++ b/source/problem.cpp
@@ -11,7 +11,7 @@ void InitProblem(nb::module_ &m)
     nb::class_<Operon::Problem>(m, "Problem")
         .def("__init__", [](Operon::Problem* problem, Operon::Dataset* dataset) {
             new (problem) Operon::Problem(gsl::not_null<Operon::Dataset*>(dataset));
-        })
+        }, nb::keep_alive<1, 2>())
         .def("ConfigurePrimitiveSet", &Operon::Problem::ConfigurePrimitiveSet)
         .def_prop_rw("TrainingRange", &Operon::Problem::TrainingRange, [](Operon::Problem& self, Operon::Range range) {
             self.SetTrainingRange(range);


### PR DESCRIPTION
## Summary

#60 fixed the use-after-free dangling-pointer bug (composite bindings storing non-owning raw pointers to inline Python temporaries) for `MultiMutation.Add`, `MultiEvaluator.Add`, `CoefficientOptimizer`, the optimizer classes, and the `Evaluator` family. #59's report explicitly called out several other constructors with the same underlying storage pattern that weren't covered because the original repro never happened to hit them (every example always used named local variables for these particular args):

- `GeneticProgrammingAlgorithm`/`NSGA2Algorithm` — `problem`, tree/coefficient initializers, `generator`, `reinserter`[, `sorter`]
- `BasicOffspringGenerator`/`OffspringSelectionGenerator`/`BroodOffspringGenerator`/`PolygenicOffspringGenerator` — `evaluator`, `crossover`, `mutator`, both selectors, coefficient optimizer
- `UniformLengthTreeInitializer` — `creator`
- `ReplaceSubtreeMutation`/`InsertSubtreeMutation` — `creator`, `coefficient initializer`

I verified each of these classes stores the corresponding constructor argument as a non-owning `gsl::not_null<... const*>` in the C++ headers (`ga_base.hpp`, `generator.hpp`, `initializer.hpp`, `mutation.hpp`), confirming they're subject to the exact same dangling-pointer pattern.

## Fix

Add `nb::keep_alive<1, N>()` for every stored pointer argument, same pattern #60 used.

## Repro

Constructed `GeneticProgrammingAlgorithm` and `BasicOffspringGenerator` with inline temporaries for the tree/coefficient initializers, reinserter, and coefficient optimizer (a natural Python idiom, same as #59's original report):

```python
gp = Operon.GeneticProgrammingAlgorithm(
    config, problem,
    Operon.UniformLengthTreeInitializer(btc),
    Operon.NormalCoefficientInitializer(),
    generator,
    Operon.ReplaceWorstReinserter(objective_index=0),
)
```

On current `main`, this doesn't crash immediately (CPython's refcounting frees the temporaries right away, but the freed memory isn't reused yet) — I had to force it with `gc.collect()` + allocating/discarding a large amount of heap garbage to get the freed memory actually overwritten before `gp.Run(...)`. With that forcing, it segfaulted reliably (3/3 runs). After adding the `keep_alive` policies, the identical repro (with the same forced heap churn) ran clean 3/3.

## Test plan

- [x] Built via `cmake --build` in the nix devshell
- [x] Repro above (inline temporaries + forced `gc.collect()`/heap churn + `Run()`) segfaults on `main`, runs clean with this fix
- [x] `example/operon-bindings.py` (full GP run, named local variables as before) still runs to completion with unchanged results

Fixes #59 (remaining half — the crash-causing part was already fixed by #60, but the report listed these as not-yet-audited)