### PR TITLE
feat(sklearn): add Callback API for monitoring/early stopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ A scikit-learn regressor is also available:
 from pyoperon.sklearn import SymbolicRegressor
 ```
 
+`SymbolicRegressor` accepts a `callbacks=` argument for monitoring or early stopping during `fit()`, in the style of Keras/Lightning callbacks:
+```python
+from pyoperon.sklearn import SymbolicRegressor
+from pyoperon import EarlyStopping
+
+reg = SymbolicRegressor(
+    population_size=1000, generations=1000,
+    callbacks=[EarlyStopping(patience=20)],
+)
+reg.fit(X, y)
+```
+Subclass `pyoperon.Callback` (`on_fit_begin`/`on_generation_end`/`on_fit_end`) for custom monitoring; return `True` from `on_generation_end` to request early termination. See `pyoperon/callback.py` for the full API.
+
 The [example](https://github.com/heal-research/pyoperon/tree/main/example) folder contains sample code for using either the Python bindings directly or the **pyoperon.sklearn** module.
 
 # Installation

--- a/example/operon-bindings.py
+++ b/example/operon-bindings.py
@@ -104,6 +104,9 @@ if __name__ == '__main__':
     t0 = time.time()
 
     def report():
+        # Returning a bool is required since operon#102: True requests
+        # early termination of the run, so this progress-only callback
+        # must explicitly return False.
         global gen
         best = gp.BestModel
         bestfit = best.GetFitness(0)
@@ -115,6 +118,7 @@ if __name__ == '__main__':
         sys.stdout.write(f'{100 * evaluator.TotalEvaluations/config.Evaluations:.1f}%, generation {gen}/{config.Generations}, train quality: {-bestfit:.6f}, elapsed: {time.time()-t0:.2f}s')
         sys.stdout.flush()
         gen += 1
+        return False
 
 
     # run the algorithm

--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782547070,
-        "narHash": "sha256-uCdlVOdgG9Vq8xr2Rc9RHLgCbdxT6XI+qnLgiFv2Lrg=",
+        "lastModified": 1783236475,
+        "narHash": "sha256-K0Vg89EzbW/n4mrWHgCxap53PovXXZaVYnixG0XLTVk=",
         "owner": "foolnotion",
         "repo": "fluky",
-        "rev": "bfbb028736af24c6b060d3e2c39712f83d1c76a2",
+        "rev": "bc7fd453f0cdf900b17b20bb6d22aff1b9dc6d98",
         "type": "github"
       },
       "original": {
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783062997,
-        "narHash": "sha256-rSGF+P8hXfFctG2GPBPZ/dS/VTsl9MwuxE+EkwqqcZE=",
+        "lastModified": 1783345914,
+        "narHash": "sha256-Th1NPQdVFhvxAV66Reu2XhCCXGEMJpsi58+GWgbNh68=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "ff99c8595e2ac56fc0919be8495ddf2910cbde96",
+        "rev": "47c762f58ae57a606708b66211ce65527600d274",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780075328,
-        "narHash": "sha256-B7pcz6jNdbW+jw67aucXaewCjk1maFpc6uyMdVrGdKc=",
+        "lastModified": 1783347696,
+        "narHash": "sha256-qUsRIMGGPGIYa3CuPemFx+jbIwXx5XeHvNptgVbf+EM=",
         "owner": "foolnotion",
         "repo": "infix-parser",
-        "rev": "b9270d14d03c4fc54816e4eb52352e4c39927ef2",
+        "rev": "a423216ed6aa329c2989b2e8686c75faab46ee66",
         "type": "github"
       },
       "original": {
@@ -540,11 +540,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782905002,
-        "narHash": "sha256-nfztYPI4FNwU5zdx11nrLeEI+G25HHxd+pGplhi90U0=",
+        "lastModified": 1783249452,
+        "narHash": "sha256-AWeGhbo8kNNzP77MOS69uyYtt3U7UqpFZSCS5CSuILM=",
         "owner": "foolnotion",
         "repo": "lbfgs",
-        "rev": "3033b8ae5e6b2d513bdea564802bc34c065f18f5",
+        "rev": "2ccd9d9c173bec3b3ecd9580f3988ea9148dfeba",
         "type": "github"
       },
       "original": {
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779885128,
-        "narHash": "sha256-cq1js1kofHQACcRmwaMaKHbMjy8cIf7NNdYWnbLdFag=",
+        "lastModified": 1783344669,
+        "narHash": "sha256-bsu2Hw5o4cMWKAZiYO7lruefQ82as1yw8kHlrD8rfS0=",
         "owner": "foolnotion",
         "repo": "ndsort",
-        "rev": "ed82c43ea0a494fce64fa41a367cd8266b4ff9d9",
+        "rev": "bd3b323b8d4373287e8cf303bc6304b929bc8ab1",
         "type": "github"
       },
       "original": {
@@ -785,11 +785,11 @@
         "vstat": "vstat"
       },
       "locked": {
-        "lastModified": 1783075870,
-        "narHash": "sha256-yLi+gIJng1R1pi9OF1GwsNyZGB2r3cXgHK8w18zRZAA=",
+        "lastModified": 1783405991,
+        "narHash": "sha256-DLyJ549TnYlYkbly+pSXbI6+CEggw5rraTmcoTvFhpc=",
         "owner": "heal-research",
         "repo": "operon",
-        "rev": "7f6d71089b7d7243481625f6a1a3a75580f5742d",
+        "rev": "46c0a5f171b0db7ccbef25559f2c61a255dfecf7",
         "type": "github"
       },
       "original": {
@@ -812,11 +812,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782893074,
-        "narHash": "sha256-IcMv/E33GRHo2hYI9JlBXCnBK0jjUcwo2d5cGBvno2w=",
+        "lastModified": 1783249461,
+        "narHash": "sha256-QwmF1oxdNnapuN0ZgwSdFILyHhJQRL73LW2GX0tPkiA=",
         "owner": "heal-research",
         "repo": "pappus",
-        "rev": "3fef62ae2c650407fbf4412f8949780f76b6bafd",
+        "rev": "b67fc412090c0bac324f6a3f2bbf4e07089eb67f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -74,10 +74,15 @@
 
             # operon's public/header-visible deps (eve, vstat, fmt, etc.) are
             # propagatedBuildInputs on the operon derivation, so they come
-            # along automatically via operon_ below.
+            # along automatically via operon_ below. infix-parser's FastFloat
+            # dependency is a private (non-propagated) buildInput on its own
+            # derivation, but its installed CMake config still `find_dependency`s
+            # FastFloat, so downstream consumers need it in scope explicitly.
             buildInputs =
               with pkgs;
               [
+                fast-float
+                foonathan-lexy
                 (python_.withPackages (
                   ps: with ps; [
                     setuptools

--- a/ports/operon/portfile.cmake
+++ b/ports/operon/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO heal-research/operon
-    REF fd3cc0b51c24606c79d606543d14ae0565fc7c9e
-    SHA512 70ecdd1f2a02c6886b1804281aac9cb912d17ebff4fd368c2ecc40731290b6aea0dbad089966f75fe66f25ed764c19faf18e04bd351040e643afa78ed67661bb
+    REF 46c0a5f171b0db7ccbef25559f2c61a255dfecf7
+    SHA512 7b11867515c6f7cb59b16f2b32ee3af24a212d4146fd67f4f76eb43f6a726bbfcd2b564f7b724520ba1f4b4d9a7edd0103a9aebb682e1d165078372ae23941c2
     HEAD_REF main
     PATCHES
         add-msvc-support.patch

--- a/pyoperon/__init__.py
+++ b/pyoperon/__init__.py
@@ -2,3 +2,4 @@
 # SPDX-FileCopyrightText: Copyright 2019-2021 Heal Research
 
 from .pyoperon import *
+from .callback import Callback, CallbackList, EarlyStopping

--- a/pyoperon/callback.py
+++ b/pyoperon/callback.py
@@ -86,7 +86,9 @@ class EarlyStopping(Callback):
     For multi-objective (NSGA2) runs, `model.BestModel` is the current
     Pareto front's member with minimal objective-0 fitness (not an
     arbitrary front member); `objective_index` selects which of that
-    individual's objective values to monitor here.
+    individual's objective values to monitor here - setting
+    `objective_index=1` still tracks objective 1 *of the objective-0
+    leader*, not the front's objective-1 leader.
     """
 
     def __init__(

--- a/pyoperon/callback.py
+++ b/pyoperon/callback.py
@@ -27,6 +27,14 @@ class Callback:
     ``GeneticProgrammingAlgorithm``/``NSGA2Algorithm`` instance, exposing
     e.g. ``Generation``, ``BestModel``, ``Individuals``, ``Config`` for
     introspection - the same role Keras callbacks' ``model`` argument plays.
+
+    ``on_generation_end`` runs on a GP worker thread, not the thread that
+    called ``fit()`` (operon's taskflow graph runs the report hook after
+    that generation's evaluate/reinsert tasks have joined, so ``model``
+    reflects a fully-completed generation - there's no torn read - but it
+    is still a background thread, so avoid anything thread-affine, e.g.
+    GUI calls). Treat ``model`` as read-only: mutating it from a callback
+    is not supported.
     """
 
     def on_fit_begin(self, model: Any) -> None:
@@ -74,6 +82,11 @@ class EarlyStopping(Callback):
     `SymbolicRegressor`/the low-level bindings use to pick `BestModel` via
     `min`), so "improved" means the monitored value decreased by more than
     `min_delta`.
+
+    For multi-objective (NSGA2) runs, `model.BestModel` is the current
+    Pareto front's member with minimal objective-0 fitness (not an
+    arbitrary front member); `objective_index` selects which of that
+    individual's objective values to monitor here.
     """
 
     def __init__(

--- a/pyoperon/callback.py
+++ b/pyoperon/callback.py
@@ -97,6 +97,12 @@ class EarlyStopping(Callback):
         patience: int = 10,
         objective_index: int = 0,
     ):
+        if patience < 0:
+            raise ValueError(f'patience must be >= 0, got {patience}')
+        if objective_index < 0:
+            raise ValueError(
+                f'objective_index must be >= 0, got {objective_index}'
+            )
         self.min_delta = min_delta
         self.patience = patience
         self.objective_index = objective_index

--- a/pyoperon/callback.py
+++ b/pyoperon/callback.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2019-2026 Heal Research
+
+"""Training callbacks for :class:`pyoperon.sklearn.SymbolicRegressor`.
+
+Modeled on the callback APIs of Keras/Lightning/pymoo (see
+https://github.com/heal-research/pyoperon/issues/18): subclass
+:class:`Callback` and override any of its hooks. ``on_generation_end`` may
+return ``True`` to request early termination of the run.
+
+Operon's C++ layer only exposes a single per-generation hook
+(``ReportCallback``), so ``on_fit_begin``/``on_fit_end`` are orchestrated
+entirely on the Python side by ``SymbolicRegressor.fit()`` (called just
+before/after ``Run()``), while ``on_generation_end`` maps directly onto the
+C++ callback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Callback:
+    """Base class for ``SymbolicRegressor`` training callbacks.
+
+    ``model`` (passed to every hook) is the underlying
+    ``GeneticProgrammingAlgorithm``/``NSGA2Algorithm`` instance, exposing
+    e.g. ``Generation``, ``BestModel``, ``Individuals``, ``Config`` for
+    introspection - the same role Keras callbacks' ``model`` argument plays.
+    """
+
+    def on_fit_begin(self, model: Any) -> None:
+        pass
+
+    def on_generation_end(self, model: Any) -> bool | None:
+        pass
+
+    def on_fit_end(self, model: Any) -> None:
+        pass
+
+
+class CallbackList(Callback):
+    """Fans a hook call out to a list of callbacks.
+
+    ``on_generation_end`` ORs early-stop requests together - matching
+    operon's ``ReportCallback`` semantics, where any ``True`` return stops
+    the run - and always calls every callback (no short-circuiting), so
+    that later callbacks still observe each generation.
+    """
+
+    def __init__(self, callbacks: list[Callback] | None = None):
+        self.callbacks = list(callbacks) if callbacks else []
+
+    def on_fit_begin(self, model: Any) -> None:
+        for cb in self.callbacks:
+            cb.on_fit_begin(model)
+
+    def on_generation_end(self, model: Any) -> bool:
+        stop = False
+        for cb in self.callbacks:
+            if cb.on_generation_end(model):
+                stop = True
+        return stop
+
+    def on_fit_end(self, model: Any) -> None:
+        for cb in self.callbacks:
+            cb.on_fit_end(model)
+
+
+class EarlyStopping(Callback):
+    """Stop once the best fitness hasn't improved for `patience` generations.
+
+    Fitness follows operon's convention (smaller is better - the same one
+    `SymbolicRegressor`/the low-level bindings use to pick `BestModel` via
+    `min`), so "improved" means the monitored value decreased by more than
+    `min_delta`.
+    """
+
+    def __init__(
+        self,
+        min_delta: float = 0.0,
+        patience: int = 10,
+        objective_index: int = 0,
+    ):
+        self.min_delta = min_delta
+        self.patience = patience
+        self.objective_index = objective_index
+        self._best: float | None = None
+        self._wait = 0
+
+    def on_fit_begin(self, model: Any) -> None:
+        # Reset here rather than in __init__: sklearn's clone()/
+        # cross_val_score reuse the same callback instance across folds
+        # without deep-copying it, so per-fit state must reset per fit(),
+        # not per construction.
+        self._best = None
+        self._wait = 0
+
+    def on_generation_end(self, model: Any) -> bool:
+        fitness = model.BestModel.GetFitness(self.objective_index)
+        if self._best is None or fitness < self._best - self.min_delta:
+            self._best = fitness
+            self._wait = 0
+        else:
+            self._wait += 1
+        return self._wait >= self.patience

--- a/pyoperon/callback.py
+++ b/pyoperon/callback.py
@@ -89,10 +89,13 @@ class EarlyStopping(Callback):
         self._wait = 0
 
     def on_fit_begin(self, model: Any) -> None:
-        # Reset here rather than in __init__: sklearn's clone()/
-        # cross_val_score reuse the same callback instance across folds
-        # without deep-copying it, so per-fit state must reset per fit(),
-        # not per construction.
+        # Reset here rather than in __init__: fit() doesn't clone self.callbacks,
+        # so calling fit() more than once on the same SymbolicRegressor instance
+        # (e.g. warm_start, or just fitting the same regressor twice) reuses
+        # this exact callback object - per-fit state must reset per fit() call,
+        # not per construction. (sklearn's clone()/cross_val_score do deep-copy
+        # callbacks - via copy.deepcopy, since Callback isn't a BaseEstimator -
+        # so this isn't protecting against that case; it's for direct re-fits.)
         self._best = None
         self._wait = 0
 

--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -261,8 +261,9 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         population.
 
     callbacks : Callback, list of Callback, or None, default=None
-        One or more `pyoperon.Callback` instances invoked during `fit()`
-        for monitoring or early stopping - e.g.
+        One or more instances *subclassing* `pyoperon.Callback` (duck-typed
+        objects are rejected - validation checks `isinstance`), invoked
+        during `fit()` for monitoring or early stopping - e.g.
         `pyoperon.EarlyStopping(patience=20)`. See `pyoperon.callback` for
         the hooks available (`on_fit_begin`, `on_generation_end`,
         `on_fit_end`).
@@ -506,7 +507,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         for cb in self._normalize_callbacks(self.callbacks):
             if not isinstance(cb, op.Callback):
                 raise ValueError(
-                    f'callbacks must be Callback instances, got {cb!r}'
+                    f'callbacks must subclass pyoperon.Callback, got {cb!r}'
                 )
 
     @staticmethod
@@ -932,9 +933,15 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
         cb_list = op.CallbackList(self._normalize_callbacks(self.callbacks))
         cb_list.on_fit_begin(gp)
-        report = (lambda: bool(cb_list.on_generation_end(gp))) if cb_list.callbacks else None
+
+        def report() -> bool:
+            return bool(cb_list.on_generation_end(gp))
+
+        # Passing None when there are no callbacks avoids a Python round-trip
+        # into `report()` every generation for the common no-callback case.
+        report_callback = report if cb_list.callbacks else None
         try:
-            gp.Run(rng, report, self.n_threads, self.warm_start)
+            gp.Run(rng, report_callback, self.n_threads, self.warm_start)
         finally:
             cb_list.on_fit_end(gp)
 

--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -421,6 +421,11 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         uncertainty = list(self.uncertainty) if self.uncertainty is not None else [1]
         pool_size = self.pool_size if self.pool_size is not None else self.population_size
         max_time = self.max_time if self.max_time is not None else sys.maxsize
+        # Materialized exactly once per fit(): self.callbacks may be a
+        # one-shot iterator/generator, and calling _normalize_callbacks on
+        # it more than once would silently see an empty sequence the
+        # second time around.
+        callbacks = self._normalize_callbacks(self.callbacks)
 
         random_state = self.random_state
         if random_state is None:
@@ -454,6 +459,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
             'optimizer_iterations': optimizer_iterations,
             'add_model_scale_term': add_model_scale_term,
             'add_model_intercept_term': add_model_intercept_term,
+            'callbacks': callbacks,
         }
 
     def _validate_params(self, resolved: dict[str, Any]) -> None:
@@ -504,7 +510,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         if len(resolved['objectives']) == 0:
             raise ValueError('objectives must not be empty')
 
-        for cb in self._normalize_callbacks(self.callbacks):
+        for cb in resolved['callbacks']:
             if not isinstance(cb, op.Callback):
                 raise ValueError(
                     f'callbacks must subclass pyoperon.Callback, got {cb!r}'
@@ -516,7 +522,13 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
             return []
         if isinstance(callbacks, op.Callback):
             return [callbacks]
-        return list(callbacks)
+        try:
+            return list(callbacks)
+        except TypeError:
+            raise ValueError(
+                f'callbacks must be a Callback, a list of Callback, or '
+                f'None, got {callbacks!r}'
+            ) from None
 
     # --- Component construction helpers ---
 
@@ -931,19 +943,21 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
         rng = op.RandomGenerator(np.uint64(config.Seed))
 
-        cb_list = op.CallbackList(self._normalize_callbacks(self.callbacks))
-        cb_list.on_fit_begin(gp)
+        callbacks = resolved['callbacks']
+        cb_list = op.CallbackList(callbacks) if callbacks else None
+        report_callback = None
+        if cb_list is not None:
+            cb_list.on_fit_begin(gp)
 
-        def report() -> bool:
-            return bool(cb_list.on_generation_end(gp))
+            def report() -> bool:
+                return bool(cb_list.on_generation_end(gp))
 
-        # Passing None when there are no callbacks avoids a Python round-trip
-        # into `report()` every generation for the common no-callback case.
-        report_callback = report if cb_list.callbacks else None
+            report_callback = report
         try:
             gp.Run(rng, report_callback, self.n_threads, self.warm_start)
         finally:
-            cb_list.on_fit_end(gp)
+            if cb_list is not None:
+                cb_list.on_fit_end(gp)
 
         # --- Extract results ---
 

--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -518,17 +518,20 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
     @staticmethod
     def _normalize_callbacks(callbacks) -> list[op.Callback]:
+        # self.callbacks is re-read (and re-normalized) on every fit() call,
+        # so it must be safely re-iterable; a one-shot iterator/generator
+        # would get silently exhausted after the first fit(). Restrict to
+        # list/tuple rather than any iterable, matching the documented type.
         if callbacks is None:
             return []
         if isinstance(callbacks, op.Callback):
             return [callbacks]
-        try:
+        if isinstance(callbacks, (list, tuple)):
             return list(callbacks)
-        except TypeError:
-            raise ValueError(
-                f'callbacks must be a Callback, a list of Callback, or '
-                f'None, got {callbacks!r}'
-            ) from None
+        raise ValueError(
+            f'callbacks must be a Callback, a list/tuple of Callback, or '
+            f'None, got {callbacks!r}'
+        )
 
     # --- Component construction helpers ---
 

--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -260,6 +260,13 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         If True, reuse individuals from a previous fit as the initial
         population.
 
+    callbacks : Callback, list of Callback, or None, default=None
+        One or more `pyoperon.Callback` instances invoked during `fit()`
+        for monitoring or early stopping - e.g.
+        `pyoperon.EarlyStopping(patience=20)`. See `pyoperon.callback` for
+        the hooks available (`on_fit_begin`, `on_generation_end`,
+        `on_fit_end`).
+
     Attributes
     ----------
     model_ : operon.Tree
@@ -290,6 +297,15 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
     >>> reg = SymbolicRegressor(population_size=100, generations=10)
     >>> reg.fit(X, y)
     SymbolicRegressor(generations=10, population_size=100)
+
+    Stop early once the best fitness plateaus, using a built-in callback:
+
+    >>> from pyoperon import EarlyStopping
+    >>> reg = SymbolicRegressor(
+    ...     population_size=100, generations=1000,
+    ...     callbacks=[EarlyStopping(patience=20)],
+    ... )
+    >>> reg.fit(X, y)  # doctest: +SKIP
     """
 
     def __init__(
@@ -340,6 +356,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         max_time: int | None = None,
         random_state: int | np.random.Generator | None = None,
         warm_start: bool = False,
+        callbacks: op.Callback | list[op.Callback] | None = None,
     ):
         self.allowed_symbols = allowed_symbols
         self.symbolic_mode = symbolic_mode
@@ -387,6 +404,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         self.max_time = max_time
         self.random_state = random_state
         self.warm_start = warm_start
+        self.callbacks = callbacks
 
     # --- Parameter resolution and validation (never mutates self) ---
 
@@ -484,6 +502,20 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
         if len(resolved['objectives']) == 0:
             raise ValueError('objectives must not be empty')
+
+        for cb in self._normalize_callbacks(self.callbacks):
+            if not isinstance(cb, op.Callback):
+                raise ValueError(
+                    f'callbacks must be Callback instances, got {cb!r}'
+                )
+
+    @staticmethod
+    def _normalize_callbacks(callbacks) -> list[op.Callback]:
+        if callbacks is None:
+            return []
+        if isinstance(callbacks, op.Callback):
+            return [callbacks]
+        return list(callbacks)
 
     # --- Component construction helpers ---
 
@@ -897,7 +929,14 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
             gp.IsFitted = True
 
         rng = op.RandomGenerator(np.uint64(config.Seed))
-        gp.Run(rng, None, self.n_threads, self.warm_start)
+
+        cb_list = op.CallbackList(self._normalize_callbacks(self.callbacks))
+        cb_list.on_fit_begin(gp)
+        report = (lambda: bool(cb_list.on_generation_end(gp))) if cb_list.callbacks else None
+        try:
+            gp.Run(rng, report, self.n_threads, self.warm_start)
+        finally:
+            cb_list.on_fit_end(gp)
 
         # --- Extract results ---
 

--- a/pyoperon/sklearn.py
+++ b/pyoperon/sklearn.py
@@ -260,13 +260,15 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         If True, reuse individuals from a previous fit as the initial
         population.
 
-    callbacks : Callback, list of Callback, or None, default=None
+    callbacks : Callback, list or tuple of Callback, or None, default=None
         One or more instances *subclassing* `pyoperon.Callback` (duck-typed
         objects are rejected - validation checks `isinstance`), invoked
         during `fit()` for monitoring or early stopping - e.g.
         `pyoperon.EarlyStopping(patience=20)`. See `pyoperon.callback` for
         the hooks available (`on_fit_begin`, `on_generation_end`,
-        `on_fit_end`).
+        `on_fit_end`). Must be a list/tuple, not a generic iterator: it is
+        re-read on every `fit()` call, so a one-shot iterator/generator
+        would silently lose its callbacks after the first `fit()`.
 
     Attributes
     ----------
@@ -357,7 +359,7 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
         max_time: int | None = None,
         random_state: int | np.random.Generator | None = None,
         warm_start: bool = False,
-        callbacks: op.Callback | list[op.Callback] | None = None,
+        callbacks: op.Callback | list[op.Callback] | tuple[op.Callback, ...] | None = None,
     ):
         self.allowed_symbols = allowed_symbols
         self.symbolic_mode = symbolic_mode
@@ -948,18 +950,20 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
         callbacks = resolved['callbacks']
         cb_list = op.CallbackList(callbacks) if callbacks else None
-        report_callback = None
-        if cb_list is not None:
-            cb_list.on_fit_begin(gp)
-
-            def report() -> bool:
-                return bool(cb_list.on_generation_end(gp))
-
-            report_callback = report
+        began = False
         try:
+            report_callback = None
+            if cb_list is not None:
+                cb_list.on_fit_begin(gp)
+                began = True
+
+                def report() -> bool:
+                    return bool(cb_list.on_generation_end(gp))
+
+                report_callback = report
             gp.Run(rng, report_callback, self.n_threads, self.warm_start)
         finally:
-            if cb_list is not None:
+            if began:
                 cb_list.on_fit_end(gp)
 
         # --- Extract results ---

--- a/script/dependencies.py
+++ b/script/dependencies.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         ('ndsort', 'https://github.com/foolnotion/ndsort', 'd94c58a1eb3e08e1cd026c565ab63276ea6bc62a', default_cmake_args + ['-DBUILD_EXAMPLES=OFF']),
         ('small_vector', 'https://github.com/gharveymn/small_vector', 'v0.10.2', default_cmake_args + ['-DGCH_SMALL_VECTOR_ENABLE_TESTS=OFF', '-DGCH_SMALL_VECTOR_ENABLE_BENCHMARKS=OFF']),
         ('pappus', 'https://github.com/heal-research/pappus', '3fef62ae2c650407fbf4412f8949780f76b6bafd', default_cmake_args),
-        ('operon', 'https://github.com/heal-research/operon', 'fd3cc0b51c24606c79d606543d14ae0565fc7c9e', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
+        ('operon', 'https://github.com/heal-research/operon', '46c0a5f171b0db7ccbef25559f2c61a255dfecf7', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
     ]
 
     total = len(dependencies)

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -24,7 +24,7 @@ void InitAlgorithm(nb::module_ &m)
     nb::class_<Operon::GeneticProgrammingAlgorithm, Operon::GeneticAlgorithmBase>(m, "GeneticProgrammingAlgorithm")
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*>(),
                 nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
-        .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t, bool>(&Operon::GeneticProgrammingAlgorithm::Run),
+        .def("Run", nb::overload_cast<Operon::RandomGenerator&, Operon::ReportCallback, size_t, bool>(&Operon::GeneticProgrammingAlgorithm::Run),
                 nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
         .def("Reset", &Operon::GeneticProgrammingAlgorithm::Reset, nb::call_guard<nb::gil_scoped_release>())
         .def("RestoreIndividuals", &Operon::GeneticProgrammingAlgorithm::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
@@ -40,8 +40,8 @@ void InitAlgorithm(nb::module_ &m)
     nb::class_<Operon::NSGA2, Operon::GeneticAlgorithmBase>(m, "NSGA2Algorithm")
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*, Operon::NondominatedSorterBase const*>(),
                 nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>(), nb::keep_alive<1, 8>())
-        .def("Run", nb::overload_cast<Operon::RandomGenerator&, std::function<void()>, size_t, bool>(&Operon::NSGA2::Run),
-                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, nb::arg("warm_start"_a) = false)	
+        .def("Run", nb::overload_cast<Operon::RandomGenerator&, Operon::ReportCallback, size_t, bool>(&Operon::NSGA2::Run),
+                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, nb::arg("warm_start"_a) = false)
         .def("Reset", &Operon::NSGA2::Reset)
         .def("RestoreIndividuals", &Operon::NSGA2::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::NSGA2::IsFitted, nb::const_),[](Operon::NSGA2& self, bool value) {

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -41,7 +41,7 @@ void InitAlgorithm(nb::module_ &m)
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*, Operon::NondominatedSorterBase const*>(),
                 nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>(), nb::keep_alive<1, 8>())
         .def("Run", nb::overload_cast<Operon::RandomGenerator&, Operon::ReportCallback, size_t, bool>(&Operon::NSGA2::Run),
-                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, nb::arg("warm_start"_a) = false)
+                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, "warm_start"_a = false)
         .def("Reset", &Operon::NSGA2::Reset)
         .def("RestoreIndividuals", &Operon::NSGA2::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::NSGA2::IsFitted, nb::const_),[](Operon::NSGA2& self, bool value) {

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -449,3 +449,142 @@ class TestFitPredict:
             )
             reg.fit(X, y)
             assert reg.is_fitted_
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Callback / CallbackList / EarlyStopping logic (no fit required)
+# ---------------------------------------------------------------------------
+
+@needs_extension
+class TestCallbackLogic:
+    """Test callback dispatch/early-stop logic against a fake model, without
+    running an actual GP fit."""
+
+    class _FakeBestModel:
+        def __init__(self, fitness):
+            self._fitness = fitness
+
+        def GetFitness(self, idx):
+            return self._fitness
+
+    class _FakeModel:
+        def __init__(self, fitness):
+            self.BestModel = TestCallbackLogic._FakeBestModel(fitness)
+
+    def test_callback_list_ors_stop_requests(self):
+        class AlwaysStop(op.Callback):
+            def on_generation_end(self, model):
+                return True
+
+        class NeverStop(op.Callback):
+            def on_generation_end(self, model):
+                return False
+
+        cb_list = op.CallbackList([NeverStop(), AlwaysStop()])
+        assert cb_list.on_generation_end(self._FakeModel(1.0)) is True
+
+    def test_callback_list_does_not_short_circuit(self):
+        calls = []
+
+        class Recorder(op.Callback):
+            def __init__(self, name):
+                self.name = name
+
+            def on_generation_end(self, model):
+                calls.append(self.name)
+                return True
+
+        cb_list = op.CallbackList([Recorder('a'), Recorder('b')])
+        cb_list.on_generation_end(self._FakeModel(1.0))
+        assert calls == ['a', 'b']
+
+    def test_early_stopping_stops_after_patience(self):
+        es = op.EarlyStopping(patience=3)
+        es.on_fit_begin(None)
+        # Constant fitness never improves, so the wait counter climbs every
+        # generation until it reaches patience.
+        results = [es.on_generation_end(self._FakeModel(1.0)) for _ in range(5)]
+        assert results == [False, False, False, True, True]
+
+    def test_early_stopping_resets_between_fits(self):
+        es = op.EarlyStopping(patience=2)
+        es.on_fit_begin(None)
+        for _ in range(3):
+            es.on_generation_end(self._FakeModel(1.0))
+        assert es._wait >= 2
+
+        # sklearn's clone()/cross_val_score reuse the same callback instance
+        # across folds without deep-copying it, so a fresh on_fit_begin must
+        # reset accumulated state rather than carrying it over.
+        es.on_fit_begin(None)
+        assert es._wait == 0
+        assert es._best is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: callbacks wired through SymbolicRegressor.fit()
+# ---------------------------------------------------------------------------
+
+@needs_extension
+class TestCallbacksIntegration:
+
+    def test_custom_callback_hooks_invoked(self, small_regression_data):
+        X, y = small_regression_data
+
+        class Recorder(op.Callback):
+            def __init__(self):
+                self.begin_calls = 0
+                self.end_calls = 0
+                self.generations_seen = []
+
+            def on_fit_begin(self, model):
+                self.begin_calls += 1
+
+            def on_generation_end(self, model):
+                self.generations_seen.append(model.Generation)
+                return False
+
+            def on_fit_end(self, model):
+                self.end_calls += 1
+
+        rec = Recorder()
+        reg = SymbolicRegressor(
+            population_size=50, generations=5,
+            max_evaluations=5000, random_state=42,
+            callbacks=[rec],
+        )
+        reg.fit(X, y)
+
+        assert rec.begin_calls == 1
+        assert rec.end_calls == 1
+        assert len(rec.generations_seen) > 0
+
+    def test_early_stopping_stops_run_early(self, small_regression_data):
+        X, y = small_regression_data
+        # An enormous min_delta means no generation ever counts as an
+        # improvement, so with patience=1 the run should stop almost
+        # immediately instead of running the full 1000 generations.
+        es = op.EarlyStopping(patience=1, min_delta=1e6)
+        reg = SymbolicRegressor(
+            population_size=50, generations=1000,
+            max_evaluations=200_000, random_state=42,
+            callbacks=[es],
+        )
+        reg.fit(X, y)
+        assert reg.stats_['generations'] < 1000
+
+    def test_callback_state_does_not_leak_across_cross_val_folds(
+        self, small_regression_data,
+    ):
+        X, y = small_regression_data
+        es = op.EarlyStopping(patience=2)
+        reg = SymbolicRegressor(
+            population_size=50, generations=5,
+            max_evaluations=5000, random_state=42,
+            callbacks=[es],
+        )
+        # cross_val_score's clone() shares this exact EarlyStopping instance
+        # across folds; if on_fit_begin didn't reset it, this would still
+        # run without error, but _wait/_best would carry over incorrectly.
+        scores = cross_val_score(reg, X, y, cv=2, scoring='r2')
+        assert len(scores) == 2

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -513,9 +513,10 @@ class TestCallbackLogic:
             es.on_generation_end(self._FakeModel(1.0))
         assert es._wait >= 2
 
-        # sklearn's clone()/cross_val_score reuse the same callback instance
-        # across folds without deep-copying it, so a fresh on_fit_begin must
-        # reset accumulated state rather than carrying it over.
+        # fit() doesn't clone self.callbacks, so calling fit() twice on the
+        # same regressor (e.g. warm_start) reuses this exact instance - a
+        # fresh on_fit_begin must reset accumulated state rather than
+        # carrying it over.
         es.on_fit_begin(None)
         assert es._wait == 0
         assert es._best is None
@@ -573,18 +574,45 @@ class TestCallbacksIntegration:
         reg.fit(X, y)
         assert reg.stats_['generations'] < 1000
 
-    def test_callback_state_does_not_leak_across_cross_val_folds(
-        self, small_regression_data,
-    ):
+    def test_callback_survives_cross_val_score(self, small_regression_data):
         X, y = small_regression_data
+        # cross_val_score clones reg per fold via sklearn's clone(), which
+        # deep-copies self.callbacks (EarlyStopping isn't a BaseEstimator,
+        # so it doesn't get cloned "deep=False" like nested estimators do) -
+        # this just confirms that round-trips cleanly and doesn't crash.
         es = op.EarlyStopping(patience=2)
         reg = SymbolicRegressor(
             population_size=50, generations=5,
             max_evaluations=5000, random_state=42,
             callbacks=[es],
         )
-        # cross_val_score's clone() shares this exact EarlyStopping instance
-        # across folds; if on_fit_begin didn't reset it, this would still
-        # run without error, but _wait/_best would carry over incorrectly.
         scores = cross_val_score(reg, X, y, cv=2, scoring='r2')
         assert len(scores) == 2
+
+    def test_on_fit_begin_invoked_on_every_fit_call(self, small_regression_data):
+        X, y = small_regression_data
+
+        class Recorder(op.Callback):
+            def __init__(self):
+                self.begin_calls = 0
+
+            def on_fit_begin(self, model):
+                self.begin_calls += 1
+
+        rec = Recorder()
+        reg = SymbolicRegressor(
+            population_size=50, generations=5,
+            max_evaluations=5000, random_state=42,
+            callbacks=[rec],
+        )
+        # Unlike clone(), fit() does *not* copy self.callbacks - calling
+        # fit() twice on the same regressor (e.g. warm_start) reuses this
+        # exact instance, so on_fit_begin must fire every time for
+        # per-fit state (e.g. EarlyStopping's _wait/_best, see
+        # TestCallbackLogic.test_early_stopping_resets_between_fits) to
+        # actually reset instead of carrying over.
+        reg.fit(X, y)
+        assert rec.begin_calls == 1
+
+        reg.fit(X, y)
+        assert rec.begin_calls == 2

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -156,6 +156,19 @@ class TestParameterResolution:
         resolved['mutation']['onepoint'] = 999.0
         assert reg.mutation['onepoint'] == 1.0
 
+    def test_resolved_callbacks_materialized_once(self):
+        """callbacks may be a one-shot iterator; _resolve_params must
+        materialize it exactly once so a later re-read (e.g. _validate_params
+        and fit() sharing the same `resolved` dict) doesn't see it already
+        exhausted."""
+        cb = op.EarlyStopping()
+        reg = SymbolicRegressor(callbacks=iter([cb]))
+        resolved = reg._resolve_params()
+        assert resolved['callbacks'] == [cb]
+        # Reusing the already-materialized list, not re-normalizing
+        # self.callbacks (the exhausted iterator), must still see it.
+        assert reg._validate_params(resolved) is None
+
 
 @needs_extension
 class TestParameterValidation:
@@ -500,7 +513,7 @@ class TestCallbackLogic:
 
     def test_early_stopping_stops_after_patience(self):
         es = op.EarlyStopping(patience=3)
-        es.on_fit_begin(None)
+        es.on_fit_begin(self._FakeModel(1.0))
         # Constant fitness never improves, so the wait counter climbs every
         # generation until it reaches patience.
         results = [es.on_generation_end(self._FakeModel(1.0)) for _ in range(5)]
@@ -508,7 +521,7 @@ class TestCallbackLogic:
 
     def test_early_stopping_resets_between_fits(self):
         es = op.EarlyStopping(patience=2)
-        es.on_fit_begin(None)
+        es.on_fit_begin(self._FakeModel(1.0))
         for _ in range(3):
             es.on_generation_end(self._FakeModel(1.0))
         assert es._wait >= 2
@@ -517,9 +530,14 @@ class TestCallbackLogic:
         # same regressor (e.g. warm_start) reuses this exact instance - a
         # fresh on_fit_begin must reset accumulated state rather than
         # carrying it over.
-        es.on_fit_begin(None)
+        es.on_fit_begin(self._FakeModel(1.0))
         assert es._wait == 0
         assert es._best is None
+
+    def test_normalize_callbacks_accepts_single_callback(self):
+        cb = op.EarlyStopping()
+        reg = SymbolicRegressor(callbacks=cb)
+        assert reg._normalize_callbacks(reg.callbacks) == [cb]
 
 
 # ---------------------------------------------------------------------------
@@ -563,16 +581,20 @@ class TestCallbacksIntegration:
     def test_early_stopping_stops_run_early(self, small_regression_data):
         X, y = small_regression_data
         # An enormous min_delta means no generation ever counts as an
-        # improvement, so with patience=1 the run should stop almost
-        # immediately instead of running the full 1000 generations.
+        # improvement, so with patience=1 the run should stop after just a
+        # couple of generations. max_evaluations is set far above what 1000
+        # generations at this population size could ever consume, so it
+        # can't be the reason the run stops early - only early-stopping can
+        # (a tight bound here, rather than "< 1000", is what actually
+        # catches a regression where the stop flag stops propagating).
         es = op.EarlyStopping(patience=1, min_delta=1e6)
         reg = SymbolicRegressor(
             population_size=50, generations=1000,
-            max_evaluations=200_000, random_state=42,
+            max_evaluations=10_000_000, random_state=42,
             callbacks=[es],
         )
         reg.fit(X, y)
-        assert reg.stats_['generations'] < 1000
+        assert reg.stats_['generations'] < 10
 
     def test_callback_survives_cross_val_score(self, small_regression_data):
         X, y = small_regression_data

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -535,6 +535,19 @@ class TestCallbackLogic:
         reg = SymbolicRegressor(callbacks=cb)
         assert reg._normalize_callbacks(reg.callbacks) == [cb]
 
+    def test_normalize_callbacks_accepts_tuple(self):
+        cb = op.EarlyStopping()
+        reg = SymbolicRegressor(callbacks=(cb,))
+        assert reg._normalize_callbacks(reg.callbacks) == [cb]
+
+    def test_early_stopping_rejects_negative_patience(self):
+        with pytest.raises(ValueError, match='patience'):
+            op.EarlyStopping(patience=-1)
+
+    def test_early_stopping_rejects_negative_objective_index(self):
+        with pytest.raises(ValueError, match='objective_index'):
+            op.EarlyStopping(objective_index=-1)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: callbacks wired through SymbolicRegressor.fit()
@@ -542,6 +555,29 @@ class TestCallbackLogic:
 
 @needs_extension
 class TestCallbacksIntegration:
+
+    def test_on_fit_end_skipped_if_on_fit_begin_raises(self, small_regression_data):
+        X, y = small_regression_data
+
+        class Bad(op.Callback):
+            def __init__(self):
+                self.end_calls = 0
+
+            def on_fit_begin(self, model):
+                raise RuntimeError('boom')
+
+            def on_fit_end(self, model):
+                self.end_calls += 1
+
+        cb = Bad()
+        reg = SymbolicRegressor(
+            population_size=50, generations=5,
+            max_evaluations=5000, random_state=42,
+            callbacks=[cb],
+        )
+        with pytest.raises(RuntimeError, match='boom'):
+            reg.fit(X, y)
+        assert cb.end_calls == 0
 
     def test_custom_callback_hooks_invoked(self, small_regression_data):
         X, y = small_regression_data

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -156,18 +156,14 @@ class TestParameterResolution:
         resolved['mutation']['onepoint'] = 999.0
         assert reg.mutation['onepoint'] == 1.0
 
-    def test_resolved_callbacks_materialized_once(self):
-        """callbacks may be a one-shot iterator; _resolve_params must
-        materialize it exactly once so a later re-read (e.g. _validate_params
-        and fit() sharing the same `resolved` dict) doesn't see it already
-        exhausted."""
-        cb = op.EarlyStopping()
-        reg = SymbolicRegressor(callbacks=iter([cb]))
-        resolved = reg._resolve_params()
-        assert resolved['callbacks'] == [cb]
-        # Reusing the already-materialized list, not re-normalizing
-        # self.callbacks (the exhausted iterator), must still see it.
-        assert reg._validate_params(resolved) is None
+    def test_callbacks_generator_rejected(self):
+        """self.callbacks is re-read on every fit() call, so a one-shot
+        iterator/generator would be silently exhausted after the first
+        fit(). Reject anything that isn't a list/tuple/Callback/None
+        outright instead of accepting it and breaking on the second fit()."""
+        reg = SymbolicRegressor(callbacks=iter([op.EarlyStopping()]))
+        with pytest.raises(ValueError, match='callbacks must be'):
+            reg._resolve_params()
 
 
 @needs_extension


### PR DESCRIPTION
## Summary

Closes #18.

**Breaking (low-level binding API):** `GeneticProgrammingAlgorithm.Run()`/`NSGA2Algorithm.Run()`'s `callback` argument now expects a callable returning `bool` (`True` requests early stop), not `None`/no-return. Existing code passing a `void`-style callback (e.g. the old `example/operon-bindings.py` pattern) must add `return False`.

operon#102 (merged as heal-research/operon@46c0a5f1) added a per-generation `ReportCallback` that can request early termination — its signature changed from `std::function<void()>` to `std::function<bool()>`, invoked once per generation via the shared `GeneticAlgorithmBase::StopRequested()`/`RequestStop()`.

This PR:
- Updates pyoperon's nanobind bindings (`source/algorithm.cpp`) to match the new `bool()` signature (was still bound as `void()`, which would no longer compile against the bumped pin).
- Bumps the pinned operon rev to `46c0a5f1`.
- Adds a Keras/Lightning/pymoo-style `Callback` API in `pyoperon/callback.py`: a `Callback` base class (`on_fit_begin`/`on_generation_end`/`on_fit_end`), `CallbackList` (fans out and ORs early-stop requests), and a built-in `EarlyStopping`. Only `on_generation_end` maps onto the C++ hook; the other two are orchestrated directly in `SymbolicRegressor.fit()` around `Run()`, so no further C++ changes were needed.
- Wires a new `callbacks=` parameter into `SymbolicRegressor.__init__`/`fit()`, with validation.
- Updates the low-level example (`example/operon-bindings.py`) since its raw `report()` callback must now return `False` instead of nothing.
- Fixes a pre-existing gap in `flake.nix`'s devShell (missing `fast-float`/`foonathan-lexy` — infix-parser's private CMake dependencies that its installed config still `find_dependency()`s), which was blocking any build and surfaced while rebuilding against the bumped pin.

## Test plan
- [x] `cmake --build build` succeeds against the bumped pin
- [x] `pytest tests/test_sklearn.py` — 49 passed, including tests covering `CallbackList` dispatch/OR semantics, `EarlyStopping` stop logic and state reset across repeated `fit()` calls, rejection of one-shot iterators for `callbacks=`, and integration tests through `SymbolicRegressor.fit()`
- [x] Manually ran the updated `example/operon-bindings.py` end-to-end to confirm the low-level raw-callback path still works