### PR TITLE
refactor(bindings): rebind GA getters via lambdas instead of overload_cast/static_cast

### DIFF
--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -14,11 +14,17 @@ using namespace nb::literals;
 
 void InitAlgorithm(nb::module_ &m)
 {
+    // Bound via plain lambdas (not static_cast<...>(&Class::Method) /
+    // nb::overload_cast<>) so these keep working regardless of whether the
+    // underlying getter is a const/non-const overload pair or a single
+    // C++23 deducing-this member - a lambda just calls the member on a
+    // concrete object and lets overload resolution (or deducing-this) do
+    // the rest, rather than needing a specific overloaded symbol's address.
     nb::class_<Operon::GeneticAlgorithmBase>(m, "GeneticAlgorithmBase")
-        .def_prop_ro("Generation", static_cast<size_t (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Generation), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Individuals", static_cast<std::vector<Operon::Individual> const& (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Individuals), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Parents", static_cast<std::span<Operon::Individual const> (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Parents), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Offspring", static_cast<std::span<Operon::Individual const> (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Offspring), nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Generation", [](Operon::GeneticAlgorithmBase const& self) { return self.Generation(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Individuals", [](Operon::GeneticAlgorithmBase const& self) -> std::vector<Operon::Individual> const& { return self.Individuals(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Parents", [](Operon::GeneticAlgorithmBase const& self) { return self.Parents(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Offspring", [](Operon::GeneticAlgorithmBase const& self) { return self.Offspring(); }, nb::call_guard<nb::gil_scoped_release>())
         ;
 
     nb::class_<Operon::GeneticProgrammingAlgorithm, Operon::GeneticAlgorithmBase>(m, "GeneticProgrammingAlgorithm")
@@ -28,9 +34,10 @@ void InitAlgorithm(nb::module_ &m)
                 nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
         .def("Reset", &Operon::GeneticProgrammingAlgorithm::Reset, nb::call_guard<nb::gil_scoped_release>())
         .def("RestoreIndividuals", &Operon::GeneticProgrammingAlgorithm::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::GeneticProgrammingAlgorithm::IsFitted, nb::const_),[](Operon::GeneticProgrammingAlgorithm& self, bool value) {
-                self.IsFitted() = value;
-        }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_rw("IsFitted",
+                [](Operon::GeneticProgrammingAlgorithm const& self) { return self.IsFitted(); },
+                [](Operon::GeneticProgrammingAlgorithm& self, bool value) { self.IsFitted() = value; },
+                nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("BestModel", [](Operon::GeneticProgrammingAlgorithm const& self) {
                 auto minElem = std::min_element(self.Parents().begin(), self.Parents().end(), [&](auto const& a, auto const& b) { return a[0] < b[0]; });
                 return *minElem;
@@ -44,9 +51,10 @@ void InitAlgorithm(nb::module_ &m)
                 nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, "warm_start"_a = false)
         .def("Reset", &Operon::NSGA2::Reset)
         .def("RestoreIndividuals", &Operon::NSGA2::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::NSGA2::IsFitted, nb::const_),[](Operon::NSGA2& self, bool value) {
-                self.IsFitted() = value;
-            }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_rw("IsFitted",
+                [](Operon::NSGA2 const& self) { return self.IsFitted(); },
+                [](Operon::NSGA2& self, bool value) { self.IsFitted() = value; },
+                nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("BestModel", [](Operon::NSGA2 const& self) {
                 auto minElem = std::min_element(self.Best().begin(), self.Best().end(), [&](auto const& a, auto const& b) { return a[0] < b[0];});
                 return *minElem;

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -614,6 +614,48 @@ class TestCallbacksIntegration:
         assert rec.end_calls == 1
         assert len(rec.generations_seen) > 0
 
+    def test_algorithm_getters_reflect_population_state(self, small_regression_data):
+        """Direct coverage for GeneticAlgorithmBase.Individuals/Parents/Offspring/
+        IsFitted, exposed to Python via lambda-rebound properties (see the
+        binding rewrite in source/algorithm.cpp) rather than through Generation
+        alone, which the callback tests above already cover indirectly."""
+        X, y = small_regression_data
+        population_size = 50
+        pool_size = 10
+
+        class Recorder(op.Callback):
+            def __init__(self):
+                self.individuals_len = []
+                self.parents_len = []
+                self.offspring_len = []
+                self.is_fitted_during_fit = []
+
+            def on_generation_end(self, model):
+                self.individuals_len.append(len(model.Individuals))
+                self.parents_len.append(len(model.Parents))
+                self.offspring_len.append(len(model.Offspring))
+                self.is_fitted_during_fit.append(model.IsFitted)
+                return False
+
+        rec = Recorder()
+        reg = SymbolicRegressor(
+            population_size=population_size, pool_size=pool_size,
+            generations=3, max_evaluations=5000, random_state=42,
+            callbacks=[rec],
+        )
+        reg.fit(X, y)
+
+        assert len(rec.individuals_len) > 0
+        # Individuals is the full population + pool storage; Parents and
+        # Offspring are non-overlapping spans into it.
+        for n_ind, n_par, n_off in zip(rec.individuals_len, rec.parents_len, rec.offspring_len):
+            assert n_ind == population_size + pool_size
+            assert n_par == population_size
+            assert n_off == pool_size
+        # IsFitted is only set true once Run() completes, so it must read
+        # false throughout every generation while still inside Run().
+        assert all(fitted is False for fitted in rec.is_fitted_during_fit)
+
     def test_early_stopping_stops_run_early(self, small_regression_data):
         X, y = small_regression_data
         # An enormous min_delta means no generation ever counts as an


### PR DESCRIPTION
## Summary
- Independent prep step for operon's architecture remediation plan (item A1: collapsing `Tree::Nodes`/`GeneticAlgorithmBase` getter pairs to C++23 deducing-this).
- `nb::overload_cast<>(&Class::Method, nb::const_)` and `static_cast<Ret (Class::*)() const>(&Class::Method)` both need two genuinely distinct overloaded symbols to disambiguate the const/non-const pair. Neither works against a single deducing-this template member, which is what operon intends to collapse `Generation`/`Individuals`/`Parents`/`Offspring`/`IsFitted` (and `Tree::Nodes`, already lambda-bound) into.
- Rebinds these five properties via plain lambdas instead — a lambda just calls the member on a concrete object, so it works identically whether the underlying method is a const/non-const overload pair (today) or a single deducing-this member (after operon's change lands).
- No behavior change; this is a pure binding-mechanism swap, safe to land independently of and ahead of the operon-side change.

**Update (review):** the original test plan only exercised `Generation` (indirectly, via callbacks) — added a direct test asserting `Individuals`/`Parents`/`Offspring` report the expected population/pool sizes each generation, and that `IsFitted` reads `False` throughout (only set `True` once `Run()` returns), giving direct coverage for the other four rebound properties this PR touches.

## Test plan
- [x] Configured + built (`cmake --preset build-linux`, `cmake --build build`) against pyoperon's currently-pinned operon rev — compiles clean.
- [x] Full `tests/test_sklearn.py` suite green: 67 passed (66 previously + 1 new), directly covering `Individuals`/`Parents`/`Offspring`/`IsFitted` in addition to `Generation`.