### PR TITLE
fix(algorithm): rebind Run/getters against operon's deducing-this API and move_only_function callback

### DIFF
--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -23,7 +23,12 @@ void InitAlgorithm(nb::module_ &m)
     // overload the compiler picks for a `const&`.
     nb::class_<Operon::GeneticAlgorithmBase>(m, "GeneticAlgorithmBase")
         .def_prop_ro("Generation", [](Operon::GeneticAlgorithmBase const& self) { return self.Generation(); }, nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Individuals", [](Operon::GeneticAlgorithmBase const& self) -> auto const& { return self.Individuals(); }, nb::call_guard<nb::gil_scoped_release>())
+        // Explicit return type, not auto const&: if a future operon revision
+        // ever changed Individuals() to return by value, `auto const&` would
+        // silently bind a reference to a temporary (a dangling-reference
+        // compiler warning at best); spelling the type out here turns that
+        // into a hard compile error instead.
+        .def_prop_ro("Individuals", [](Operon::GeneticAlgorithmBase const& self) -> std::vector<Operon::Individual> const& { return self.Individuals(); }, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("Parents", [](Operon::GeneticAlgorithmBase const& self) { return self.Parents(); }, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("Offspring", [](Operon::GeneticAlgorithmBase const& self) { return self.Offspring(); }, nb::call_guard<nb::gil_scoped_release>())
         ;

--- a/source/algorithm.cpp
+++ b/source/algorithm.cpp
@@ -14,21 +14,36 @@ using namespace nb::literals;
 
 void InitAlgorithm(nb::module_ &m)
 {
+    // GeneticAlgorithmBase's getters are C++23 deducing-this members
+    // (`auto Generation(this Self&& self)` etc.), not const/non-const
+    // overload pairs, so there's no single member-function-pointer type to
+    // take the address of for nb::overload_cast/static_cast the way the old
+    // getter-pair style allowed. Lambdas calling through the const-qualified
+    // `self` sidestep that - they just invoke whichever deducing-this
+    // overload the compiler picks for a `const&`.
     nb::class_<Operon::GeneticAlgorithmBase>(m, "GeneticAlgorithmBase")
-        .def_prop_ro("Generation", static_cast<size_t (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Generation), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Individuals", static_cast<std::vector<Operon::Individual> const& (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Individuals), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Parents", static_cast<std::span<Operon::Individual const> (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Parents), nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_ro("Offspring", static_cast<std::span<Operon::Individual const> (Operon::GeneticAlgorithmBase::*)() const>(&Operon::GeneticAlgorithmBase::Offspring), nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Generation", [](Operon::GeneticAlgorithmBase const& self) { return self.Generation(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Individuals", [](Operon::GeneticAlgorithmBase const& self) -> auto const& { return self.Individuals(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Parents", [](Operon::GeneticAlgorithmBase const& self) { return self.Parents(); }, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("Offspring", [](Operon::GeneticAlgorithmBase const& self) { return self.Offspring(); }, nb::call_guard<nb::gil_scoped_release>())
         ;
 
     nb::class_<Operon::GeneticProgrammingAlgorithm, Operon::GeneticAlgorithmBase>(m, "GeneticProgrammingAlgorithm")
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*>(),
                 nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>())
-        .def("Run", nb::overload_cast<Operon::RandomGenerator&, Operon::ReportCallback, size_t, bool>(&Operon::GeneticProgrammingAlgorithm::Run),
-                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
+        // Operon::ReportCallback is std::move_only_function, which nanobind
+        // has no built-in caster for (only nanobind/stl/function.h, i.e.
+        // std::function). This lambda takes the std::function nanobind can
+        // bind from a Python callable and converts it to ReportCallback at
+        // the call site instead.
+        .def("Run", [](Operon::GeneticProgrammingAlgorithm& self, Operon::RandomGenerator& rng, std::function<bool()> callback, size_t threads, bool warmStart) {
+                self.Run(rng, Operon::ReportCallback(std::move(callback)), threads, warmStart);
+            }, nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), nb::arg("callback") = nullptr, nb::arg("threads") = 0, nb::arg("warm_start") = false)
         .def("Reset", &Operon::GeneticProgrammingAlgorithm::Reset, nb::call_guard<nb::gil_scoped_release>())
         .def("RestoreIndividuals", &Operon::GeneticProgrammingAlgorithm::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::GeneticProgrammingAlgorithm::IsFitted, nb::const_),[](Operon::GeneticProgrammingAlgorithm& self, bool value) {
+        // See GeneticAlgorithmBase's getters above for why this is a lambda
+        // rather than nb::overload_cast against a deducing-this member.
+        .def_prop_rw("IsFitted",[](Operon::GeneticProgrammingAlgorithm const& self) { return self.IsFitted(); },[](Operon::GeneticProgrammingAlgorithm& self, bool value) {
                 self.IsFitted() = value;
         }, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("BestModel", [](Operon::GeneticProgrammingAlgorithm const& self) {
@@ -40,11 +55,16 @@ void InitAlgorithm(nb::module_ &m)
     nb::class_<Operon::NSGA2, Operon::GeneticAlgorithmBase>(m, "NSGA2Algorithm")
         .def(nb::init<Operon::GeneticAlgorithmConfig, Operon::Problem const*, Operon::TreeInitializerBase const*, Operon::CoefficientInitializerBase const*, Operon::OffspringGeneratorBase const*, Operon::ReinserterBase const*, Operon::NondominatedSorterBase const*>(),
                 nb::keep_alive<1, 3>(), nb::keep_alive<1, 4>(), nb::keep_alive<1, 5>(), nb::keep_alive<1, 6>(), nb::keep_alive<1, 7>(), nb::keep_alive<1, 8>())
-        .def("Run", nb::overload_cast<Operon::RandomGenerator&, Operon::ReportCallback, size_t, bool>(&Operon::NSGA2::Run),
-                nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, "warm_start"_a = false)
+        // See GeneticProgrammingAlgorithm's Run binding above for why this is
+        // a std::function-taking lambda rather than nb::overload_cast directly.
+        .def("Run", [](Operon::NSGA2& self, Operon::RandomGenerator& rng, std::function<bool()> callback, size_t threads, bool warmStart) {
+                self.Run(rng, Operon::ReportCallback(std::move(callback)), threads, warmStart);
+            }, nb::call_guard<nb::gil_scoped_release>(), nb::arg("rng"), "callback"_a = nb::none(), "threads"_a = 0, "warm_start"_a = false)
         .def("Reset", &Operon::NSGA2::Reset)
         .def("RestoreIndividuals", &Operon::NSGA2::RestoreIndividuals, nb::call_guard<nb::gil_scoped_release>())
-        .def_prop_rw("IsFitted",nb::overload_cast<>(&Operon::NSGA2::IsFitted, nb::const_),[](Operon::NSGA2& self, bool value) {
+        // See GeneticAlgorithmBase's getters above for why this is a lambda
+        // rather than nb::overload_cast against a deducing-this member.
+        .def_prop_rw("IsFitted",[](Operon::NSGA2 const& self) { return self.IsFitted(); },[](Operon::NSGA2& self, bool value) {
                 self.IsFitted() = value;
             }, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("BestModel", [](Operon::NSGA2 const& self) {


### PR DESCRIPTION
## Summary
- Companion fix for [operon#118](https://github.com/heal-research/operon/pull/118) (C2: `ReportCallback` becomes `std::move_only_function`). `GeneticProgrammingAlgorithm::Run`/`NSGA2::Run` bindings switch from `nb::overload_cast<...>(&Run)` to a lambda taking `std::function<bool()>` (which nanobind can bind from Python) and converting it to `Operon::ReportCallback` at the call site — nanobind has no built-in caster for `move_only_function`.
- Also fixes a **separate, pre-existing** break: `GeneticAlgorithmBase::Generation/Individuals/Parents/Offspring` and `GeneticProgrammingAlgorithm`/`NSGA2::IsFitted` bindings were still written against the old const/non-const getter-pair style (`nb::overload_cast<...>`/`static_cast<Ret (Class::*)() const>`), which no longer resolves against operon's deducing-this getters (operon's own PR #115, merged earlier). This has apparently been silently broken since then because pyoperon's pin never advanced past it — not something this PR's own changes introduced.
- This PR does **not** touch `flake.lock`. It's source-only and backward-compatible with pyoperon's currently-pinned operon rev (a `std::function`→`std::function` conversion is a no-op when `ReportCallback` is still `std::function`, and the deducing-this getters already exist at HEAD but not at the currently-pinned rev — so this compiles against both). Repinning to pick up operon#118 once merged is a separate follow-up.

## Not in scope
Verified along the way that `.Parents`/`.Offspring` (returning `std::span<Individual const>`) hit an unrelated, pre-existing `TypeError` at runtime — this environment's nanobind has no caster for `std::span` at all, and nothing in pyoperon's own tests/examples ever exercises those two properties, so it's a latent gap that predates all of this and isn't touched here.

## Test plan
- [x] Built against a local flake `path:`/`git+file:` override of operon's `refactor/move-only-function-callbacks` branch (reverted before this commit) — `algorithm.cpp` compiles and the module links
- [x] Ran a real GP fit from Python with a report callback against that build — callback fired correctly across the full run, `Generation`/`Individuals`/`IsFitted` all readable afterward