### PR TITLE
fix(bindings): keep GetVariable's None-on-miss contract as operon moves to tl::expected

### DIFF
--- a/source/dataset.cpp
+++ b/source/dataset.cpp
@@ -104,11 +104,11 @@ void InitDataset(nb::module_ &m)
         .def("GetValues", [](Operon::Dataset const& self, int64_t index) { return MakeView(self.GetValues(index), nb::find(self)); })
         .def("GetVariable", [](Operon::Dataset const& self, std::string const& name) -> std::optional<Operon::Variable> {
             auto res = self.GetVariable(name);
-            return res.has_value() ? std::optional{*res} : std::nullopt;
+            return res.has_value() ? std::optional{std::move(*res)} : std::nullopt;
         })
         .def("GetVariable", [](Operon::Dataset const& self, Operon::Hash hash) -> std::optional<Operon::Variable> {
             auto res = self.GetVariable(hash);
-            return res.has_value() ? std::optional{*res} : std::nullopt;
+            return res.has_value() ? std::optional{std::move(*res)} : std::nullopt;
         })
         .def_prop_ro("Variables", &Operon::Dataset::GetVariables)
         .def("SetWeights", [](Operon::Dataset& self, std::vector<Operon::Scalar> const& w) { self.SetWeights(w); })

--- a/source/dataset.cpp
+++ b/source/dataset.cpp
@@ -4,6 +4,7 @@
 #include <operon/core/dataset.hpp>
 #include <utility>
 
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
 
 #include "pyoperon/pyoperon.hpp"
@@ -101,8 +102,14 @@ void InitDataset(nb::module_ &m)
         .def("GetValues", [](Operon::Dataset const& self, std::string const& name) { return MakeView(self.GetValues(name), nb::find(self)); })
         .def("GetValues", [](Operon::Dataset const& self, Operon::Hash hash) { return MakeView(self.GetValues(hash), nb::find(self)); })
         .def("GetValues", [](Operon::Dataset const& self, int64_t index) { return MakeView(self.GetValues(index), nb::find(self)); })
-        .def("GetVariable", nb::overload_cast<const std::string&>(&Operon::Dataset::GetVariable, nb::const_))
-        .def("GetVariable", nb::overload_cast<Operon::Hash>(&Operon::Dataset::GetVariable, nb::const_))
+        .def("GetVariable", [](Operon::Dataset const& self, std::string const& name) -> std::optional<Operon::Variable> {
+            auto res = self.GetVariable(name);
+            return res.has_value() ? std::optional{*res} : std::nullopt;
+        })
+        .def("GetVariable", [](Operon::Dataset const& self, Operon::Hash hash) -> std::optional<Operon::Variable> {
+            auto res = self.GetVariable(hash);
+            return res.has_value() ? std::optional{*res} : std::nullopt;
+        })
         .def_prop_ro("Variables", &Operon::Dataset::GetVariables)
         .def("SetWeights", [](Operon::Dataset& self, std::vector<Operon::Scalar> const& w) { self.SetWeights(w); })
         // Like GetValues/Values above, this is a view into weights_; a

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -32,7 +32,7 @@ def test_variablenames_roundtrip_on_ndarray_dataset():
 
 
 @pytest.fixture
-def _named_dataset():
+def named_dataset():
     return op.Dataset(['X', 'Y', 'F'], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
 
 
@@ -43,17 +43,20 @@ class TestGetVariable:
     Python-facing None-on-miss contract.
     """
 
-    def test_known_name_returns_variable(self, _named_dataset):
-        var = _named_dataset.GetVariable('F')
+    def test_known_name_returns_variable(self, named_dataset):
+        var = named_dataset.GetVariable('F')
         assert var is not None
         assert var.Name == 'F'
 
-    def test_unknown_name_returns_none(self, _named_dataset):
-        assert _named_dataset.GetVariable('NOPE') is None
+    def test_unknown_name_returns_none(self, named_dataset):
+        assert named_dataset.GetVariable('NOPE') is None
 
-    def test_known_hash_returns_variable(self, _named_dataset):
-        target = _named_dataset.GetVariable('F')
-        assert _named_dataset.GetVariable(target.Hash).Name == 'F'
+    def test_known_hash_returns_variable(self, named_dataset):
+        target = named_dataset.GetVariable('F')
+        assert named_dataset.GetVariable(target.Hash).Name == 'F'
 
-    def test_unknown_hash_returns_none(self, _named_dataset):
-        assert _named_dataset.GetVariable(0) is None
+    def test_unknown_hash_returns_none(self, named_dataset):
+        # derive a hash guaranteed absent from the dataset, rather than
+        # relying on the hasher never mapping a real variable name to 0
+        unknown_hash = max(named_dataset.VariableHashes) + 1
+        assert named_dataset.GetVariable(unknown_hash) is None

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -29,3 +29,31 @@ def test_variablenames_roundtrip_on_ndarray_dataset():
     assert ds.VariableNames == ['X1', 'X2', 'X3']
     ds.VariableNames = ['a', 'b', 'c']
     assert ds.VariableNames == ['a', 'b', 'c']
+
+
+@pytest.fixture
+def _named_dataset():
+    return op.Dataset(['X', 'Y', 'F'], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+
+
+@needs_extension
+class TestGetVariable:
+    """GetVariable's C++ implementation returns tl::expected<Variable, DatasetError>,
+    shimmed back to std::optional at the binding boundary; these lock down the
+    Python-facing None-on-miss contract.
+    """
+
+    def test_known_name_returns_variable(self, _named_dataset):
+        var = _named_dataset.GetVariable('F')
+        assert var is not None
+        assert var.Name == 'F'
+
+    def test_unknown_name_returns_none(self, _named_dataset):
+        assert _named_dataset.GetVariable('NOPE') is None
+
+    def test_known_hash_returns_variable(self, _named_dataset):
+        target = _named_dataset.GetVariable('F')
+        assert _named_dataset.GetVariable(target.Hash).Name == 'F'
+
+    def test_unknown_hash_returns_none(self, _named_dataset):
+        assert _named_dataset.GetVariable(0) is None


### PR DESCRIPTION
## Summary
- Companion to heal-research/operon#119 (D1: `Dataset::GetVariable` moving from `std::optional` to `tl::expected<Variable, DatasetError>`).
- nanobind has no caster for `tl::expected`, and the previous binding relied on `nb::overload_cast` directly on the C++ signature — this would no longer compile once operon's return type changes.
- Replaces the direct `nb::overload_cast` binding with a lambda shim per overload that converts back to `std::optional<Variable>` at the boundary, so `ds.GetVariable(name)` still returns `Variable` or `None` from Python, unchanged.
- Needed an added `#include <nanobind/stl/optional.h>` for the `std::optional` caster.

## Test plan
- [x] Built the full `pyoperon` extension against operon's `refactor/dataset-getvariable-expected` branch via a local flake `path:` override
- [x] Ran a live Python `Dataset.GetVariable(...)` call confirming both the valid-name and invalid-name (`None`) cases

https://claude.ai/code/session_018UieRm939QgjUeb5aMmFVw