### PR TITLE
fix(bindings): shim OptimizerSummary over operon's tl::expected FitOutcome

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -785,11 +785,11 @@
         "vstat": "vstat"
       },
       "locked": {
-        "lastModified": 1783511287,
-        "narHash": "sha256-BsBRvz/5JPh63FrReh/613r1oRtKHfukoYi9rqpk7Pk=",
+        "lastModified": 1783940946,
+        "narHash": "sha256-n0Yuqr/rPGxTLwcRCxXyIkImF7Rc1emfBMyqVZDdkFM=",
         "owner": "heal-research",
         "repo": "operon",
-        "rev": "01117e77933d406a3efe9bd57dc6a66307ffc376",
+        "rev": "404253b6de3b60bcbd870ccd0f85b7aae619ec09",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -785,11 +785,11 @@
         "vstat": "vstat"
       },
       "locked": {
-        "lastModified": 1783940946,
-        "narHash": "sha256-n0Yuqr/rPGxTLwcRCxXyIkImF7Rc1emfBMyqVZDdkFM=",
+        "lastModified": 1783945085,
+        "narHash": "sha256-tCbkFouHtzDlIn1QSFLsUC1L6JcFVkdLaARmu5kVZ8A=",
         "owner": "heal-research",
         "repo": "operon",
-        "rev": "404253b6de3b60bcbd870ccd0f85b7aae619ec09",
+        "rev": "79566dd7ba95f6795e26c63557f8c4236a6c8ba7",
         "type": "github"
       },
       "original": {

--- a/ports/operon/add-msvc-support.patch
+++ b/ports/operon/add-msvc-support.patch
@@ -4,34 +4,10 @@ index 887d7ef5..a8288c34 100644
 +++ b/CMakeLists.txt
 @@ -254,7 +254,7 @@ target_link_libraries(operon_operon PRIVATE
  target_compile_features(operon_operon PUBLIC cxx_std_23)
- 
+
  if(MSVC)
 -    target_compile_options(operon_operon PRIVATE "/std:c++latest")
 +    target_compile_options(operon_operon PRIVATE "/bigobj")
  else()
      if (UNIX AND NOT APPLE)
          target_link_options(operon_operon PRIVATE "-Wl,--no-undefined")
-diff --git a/include/operon/optimizer/likelihood/gaussian_likelihood.hpp b/include/operon/optimizer/likelihood/gaussian_likelihood.hpp
-index 80e83b4d..b1d9e4b6 100644
---- a/include/operon/optimizer/likelihood/gaussian_likelihood.hpp
-+++ b/include/operon/optimizer/likelihood/gaussian_likelihood.hpp
-@@ -8,6 +8,7 @@
- #include <algorithm>
- #include <array>
- #include <functional>
- #include <limits>
-+#include <random>
-
- #include "operon/core/concepts.hpp"
-diff --git a/include/operon/optimizer/likelihood/poisson_likelihood.hpp b/include/operon/optimizer/likelihood/poisson_likelihood.hpp
-index 163e6c1d..1bb9c486 100644
---- a/include/operon/optimizer/likelihood/poisson_likelihood.hpp
-+++ b/include/operon/optimizer/likelihood/poisson_likelihood.hpp
-@@ -11,6 +11,7 @@
- #include "likelihood_base.hpp"
- 
- #include <functional>
-+#include <random>
- #include <type_traits>
- #include <vstat/univariate.hpp>
- #include <vstat/vstat.hpp>

--- a/ports/operon/add-msvc-support.patch
+++ b/ports/operon/add-msvc-support.patch
@@ -15,13 +15,13 @@ diff --git a/include/operon/optimizer/likelihood/gaussian_likelihood.hpp b/inclu
 index 80e83b4d..b1d9e4b6 100644
 --- a/include/operon/optimizer/likelihood/gaussian_likelihood.hpp
 +++ b/include/operon/optimizer/likelihood/gaussian_likelihood.hpp
-@@ -7,6 +7,7 @@
- 
+@@ -8,6 +8,7 @@
+ #include <algorithm>
  #include <array>
  #include <functional>
-+#include <random>
  #include <limits>
- 
++#include <random>
+
  #include "operon/core/concepts.hpp"
 diff --git a/include/operon/optimizer/likelihood/poisson_likelihood.hpp b/include/operon/optimizer/likelihood/poisson_likelihood.hpp
 index 163e6c1d..1bb9c486 100644

--- a/ports/operon/portfile.cmake
+++ b/ports/operon/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO heal-research/operon
-    REF 46c0a5f171b0db7ccbef25559f2c61a255dfecf7
-    SHA512 7b11867515c6f7cb59b16f2b32ee3af24a212d4146fd67f4f76eb43f6a726bbfcd2b564f7b724520ba1f4b4d9a7edd0103a9aebb682e1d165078372ae23941c2
+    REF 404253b6de3b60bcbd870ccd0f85b7aae619ec09
+    SHA512 eab054c23e06b60a5307d2ea60852dc76c489db1eaaf5d86d974460a9a3003a628e3f9c61165b5ceec153769e9c779a442a13401f3761dc400290a1eb9284ff2
     HEAD_REF main
     PATCHES
         add-msvc-support.patch

--- a/ports/operon/portfile.cmake
+++ b/ports/operon/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO heal-research/operon
-    REF 404253b6de3b60bcbd870ccd0f85b7aae619ec09
-    SHA512 eab054c23e06b60a5307d2ea60852dc76c489db1eaaf5d86d974460a9a3003a628e3f9c61165b5ceec153769e9c779a442a13401f3761dc400290a1eb9284ff2
+    REF 79566dd7ba95f6795e26c63557f8c4236a6c8ba7
+    SHA512 5f54b0cadabf0d7d8a870a93c1f4edc17a719a8300c8a467ae094d6e1b0e6e39ecd085e8be24bbf08946adc0dd1b87d04dd4a964b615b3718449ccfd10fa7f26
     HEAD_REF main
     PATCHES
         add-msvc-support.patch

--- a/script/dependencies.py
+++ b/script/dependencies.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         ('ndsort', 'https://github.com/foolnotion/ndsort', 'd94c58a1eb3e08e1cd026c565ab63276ea6bc62a', default_cmake_args + ['-DBUILD_EXAMPLES=OFF']),
         ('small_vector', 'https://github.com/gharveymn/small_vector', 'v0.10.2', default_cmake_args + ['-DGCH_SMALL_VECTOR_ENABLE_TESTS=OFF', '-DGCH_SMALL_VECTOR_ENABLE_BENCHMARKS=OFF']),
         ('pappus', 'https://github.com/heal-research/pappus', '3fef62ae2c650407fbf4412f8949780f76b6bafd', default_cmake_args),
-        ('operon', 'https://github.com/heal-research/operon', '46c0a5f171b0db7ccbef25559f2c61a255dfecf7', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
+        ('operon', 'https://github.com/heal-research/operon', '404253b6de3b60bcbd870ccd0f85b7aae619ec09', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
     ]
 
     total = len(dependencies)

--- a/script/dependencies.py
+++ b/script/dependencies.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         ('ndsort', 'https://github.com/foolnotion/ndsort', 'd94c58a1eb3e08e1cd026c565ab63276ea6bc62a', default_cmake_args + ['-DBUILD_EXAMPLES=OFF']),
         ('small_vector', 'https://github.com/gharveymn/small_vector', 'v0.10.2', default_cmake_args + ['-DGCH_SMALL_VECTOR_ENABLE_TESTS=OFF', '-DGCH_SMALL_VECTOR_ENABLE_BENCHMARKS=OFF']),
         ('pappus', 'https://github.com/heal-research/pappus', '3fef62ae2c650407fbf4412f8949780f76b6bafd', default_cmake_args),
-        ('operon', 'https://github.com/heal-research/operon', '404253b6de3b60bcbd870ccd0f85b7aae619ec09', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
+        ('operon', 'https://github.com/heal-research/operon', '79566dd7ba95f6795e26c63557f8c4236a6c8ba7', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
     ]
 
     total = len(dependencies)

--- a/source/optimizer.cpp
+++ b/source/optimizer.cpp
@@ -14,6 +14,39 @@
 
 namespace detail {
 
+// operon's CoefficientOptimizer/OptimizerBase::Optimize now return a
+// tl::expected<FitResult, FitFailure> outcome (nanobind has no built-in
+// caster for tl::expected). This flattens that outcome back into the same
+// field-level shape pyoperon has always exposed as "OptimizerSummary",
+// keeping the Python-facing API unchanged - callers that read `.Success`
+// still get a bool, `.FinalCost` etc. still populated regardless of outcome
+// (both FitResult and FitFailure carry full diagnostics; see
+// Operon::Diagnostics() in optimizer.hpp).
+struct PySummary {
+    std::vector<Operon::Scalar> InitialParameters;
+    std::vector<Operon::Scalar> FinalParameters;
+    Operon::Scalar InitialCost{};
+    Operon::Scalar FinalCost{};
+    int Iterations{};
+    int FunctionEvaluations{};
+    int JacobianEvaluations{};
+    bool Success{};
+};
+
+inline auto ToPySummary(Operon::FitOutcome const& outcome) -> PySummary {
+    auto const& diag = Operon::Diagnostics(outcome);
+    return PySummary{
+        diag.InitialParameters,
+        diag.FinalParameters,
+        diag.InitialCost,
+        diag.FinalCost,
+        diag.Iterations,
+        diag.FunctionEvaluations,
+        diag.JacobianEvaluations,
+        outcome.has_value()
+    };
+}
+
 class LMOptimizer : public Optimizer {
     public:
     LMOptimizer(TDispatch const& dispatch, Operon::Problem const& problem, std::size_t maxIter, std::size_t batchSize)
@@ -79,17 +112,20 @@ void InitOptimizer(nb::module_ &m)
         .def("__init__", [](Operon::CoefficientOptimizer* op, detail::Optimizer const& opt) {
             new (op) Operon::CoefficientOptimizer(opt.Get());
         }, nb::keep_alive<1, 2>())
-        .def("__call__", &Operon::CoefficientOptimizer::operator());
+        .def("__call__", [](Operon::CoefficientOptimizer const& self, Operon::RandomGenerator& rng, Operon::Tree tree) {
+            auto [t, outcome] = self(rng, std::move(tree));
+            return std::tuple{std::move(t), detail::ToPySummary(outcome)};
+        });
 
-    nb::class_<Operon::OptimizerSummary>(m, "OptimizerSummary")
-        .def_rw("InitialCost", &Operon::OptimizerSummary::InitialCost)
-        .def_rw("FinalCost", &Operon::OptimizerSummary::FinalCost)
-        .def_rw("Iterations", &Operon::OptimizerSummary::Iterations)
-        .def_rw("FunctionEvaluations", &Operon::OptimizerSummary::FunctionEvaluations)
-        .def_rw("JacobianEvaluations", &Operon::OptimizerSummary::JacobianEvaluations)
-        .def_rw("Success", &Operon::OptimizerSummary::Success)
-        .def_rw("InitialParameters", &Operon::OptimizerSummary::InitialParameters)
-        .def_rw("FinalParameters", &Operon::OptimizerSummary::FinalParameters);
+    nb::class_<detail::PySummary>(m, "OptimizerSummary")
+        .def_rw("InitialCost", &detail::PySummary::InitialCost)
+        .def_rw("FinalCost", &detail::PySummary::FinalCost)
+        .def_rw("Iterations", &detail::PySummary::Iterations)
+        .def_rw("FunctionEvaluations", &detail::PySummary::FunctionEvaluations)
+        .def_rw("JacobianEvaluations", &detail::PySummary::JacobianEvaluations)
+        .def_rw("Success", &detail::PySummary::Success)
+        .def_rw("InitialParameters", &detail::PySummary::InitialParameters)
+        .def_rw("FinalParameters", &detail::PySummary::FinalParameters);
 
 
     nb::class_<detail::Optimizer>(m, "Optimizer");

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2019-2026 Heal Research
+
+"""Tests for CoefficientOptimizer/OptimizerSummary bindings.
+
+operon's OptimizerBase::Optimize/CoefficientOptimizer::operator() return
+tl::expected<FitResult, FitFailure> (operon PR #122); source/optimizer.cpp
+shims that back into the plain-struct OptimizerSummary Python API these
+tests lock down. Exercises both the success path (fit improves) and the
+failure path (max_iter=0, mirroring GrammarEnumerationAlgorithm's own
+precondition on this exact contract in the C++ test suite).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:
+    import pyoperon as op
+    HAS_EXTENSION = True
+except ImportError:
+    HAS_EXTENSION = False
+
+needs_extension = pytest.mark.skipif(
+    not HAS_EXTENSION, reason='pyoperon C++ extension not available'
+)
+
+
+@pytest.fixture
+def linear_fixture():
+    """y = 2 * x; a single-variable tree initialized with the wrong
+    coefficient (1.0), so a coefficient fit has real room to improve."""
+    rng_np = np.random.default_rng(0)
+    X = rng_np.standard_normal((30, 1)).astype(np.float32)
+    y = (2 * X[:, 0]).astype(np.float32)
+    D = np.asfortranarray(np.column_stack((X, y)))
+    ds = op.Dataset(D)
+    target = max(ds.Variables, key=lambda v: v.Index)
+    inputs = [v.Hash for v in ds.Variables if v.Hash != target.Hash]
+
+    problem = op.Problem(ds)
+    problem.TrainingRange = op.Range(0, ds.Rows)
+    problem.Target = target
+    problem.InputHashes = inputs
+
+    var_node = op.Node.Variable(1.0)
+    var_node.HashValue = inputs[0]
+    tree = op.Tree([var_node]).UpdateNodes()
+
+    dtable = op.DispatchTable()
+    rng = op.RandomGenerator(np.uint64(0))
+    return problem, dtable, rng, tree
+
+
+@needs_extension
+class TestCoefficientOptimizer:
+    def test_success_path_improves_and_applies_coefficients(self, linear_fixture):
+        problem, dtable, rng, tree = linear_fixture
+        optimizer = op.LMOptimizer(dtable, problem, max_iter=10)
+        coeff_opt = op.CoefficientOptimizer(optimizer)
+
+        optimized_tree, summary = coeff_opt(rng, tree)
+
+        assert summary.Success is True
+        assert summary.FinalParameters == pytest.approx([2.0], abs=1e-3)
+        # applied back into the returned tree, not just reported in summary
+        assert optimized_tree.GetCoefficients() == pytest.approx([2.0], abs=1e-3)
+
+    def test_failure_path_leaves_tree_untouched(self, linear_fixture):
+        problem, dtable, rng, tree = linear_fixture
+        # max_iter=0 makes CoefficientOptimizer return early without ever
+        # calling Optimize() - the same "Iterations() == 0" contract
+        # GrammarEnumerationAlgorithm::Run's C++ test depends on.
+        optimizer = op.LMOptimizer(dtable, problem, max_iter=0)
+        coeff_opt = op.CoefficientOptimizer(optimizer)
+
+        optimized_tree, summary = coeff_opt(rng, tree)
+
+        assert summary.Success is False
+        # diagnostics still populated (empty/zero defaults), not raising -
+        # this is exactly the case the FitOutcome shim has to get right
+        assert summary.FinalParameters == []
+        assert summary.InitialCost == 0.0
+        # never applied since the fit never ran
+        assert optimized_tree.GetCoefficients() == pytest.approx([1.0])


### PR DESCRIPTION
## Summary
- operon's `OptimizerBase::Optimize`/`CoefficientOptimizer::operator()` now return `tl::expected<FitResult, FitFailure>` (operon PR #122) instead of a plain `OptimizerSummary` struct - nanobind has no built-in caster for `tl::expected`.
- Adds a `detail::PySummary` struct + `ToPySummary()` in `source/optimizer.cpp` that flattens the outcome back into the exact same field-level shape (`InitialCost`, `FinalCost`, `Iterations`, `FunctionEvaluations`, `JacobianEvaluations`, `Success`, `InitialParameters`, `FinalParameters`) pyoperon has always exposed as `OptimizerSummary` - the Python-facing API is unchanged.
- `CoefficientOptimizer.__call__`'s binding becomes a lambda (was a direct `&Operon::CoefficientOptimizer::operator()` pointer) to do the conversion at the call site.
- Bumps the operon pin to `404253b6` (includes #122).

## Test plan
- [x] `nix build .#default` succeeds against the updated operon pin