### PR TITLE
sync(bindings): adopt operon MultiEvaluator aggregate API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -785,11 +785,11 @@
         "vstat": "vstat"
       },
       "locked": {
-        "lastModified": 1784750058,
-        "narHash": "sha256-siUsTBLupo7ArZ6Yy3JIYpQfOj/aqj1R182Mi8ZCy9A=",
+        "lastModified": 1785740213,
+        "narHash": "sha256-RDuJOI50joA6V2z3HvdehcOUbaApzhw75AhsFXGlUSM=",
         "owner": "heal-research",
         "repo": "operon",
-        "rev": "26e4c48f5c6573a3ed7895548479fb6bb156bac3",
+        "rev": "1de7bce0420933b9a5b7ab8913952e79b3cc0f06",
         "type": "github"
       },
       "original": {
@@ -872,11 +872,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780595758,
-        "narHash": "sha256-EYATco7ZfRCMk53FTydO+6qwTe8CiIctF8wSw+IUbUo=",
+        "lastModified": 1784990564,
+        "narHash": "sha256-J8TXV7HyWy3oeAeYk61NsUP2NM/dRi9iuTzvFKOvV8w=",
         "owner": "heal-research",
         "repo": "vstat",
-        "rev": "dd174d0dcc4a9fe7d15e8667a2ccb69b3870ded7",
+        "rev": "495dca7736cef3db37cf6a8efced065c4befdab1",
         "type": "github"
       },
       "original": {

--- a/ports/operon/portfile.cmake
+++ b/ports/operon/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO heal-research/operon
-    REF 26e4c48f5c6573a3ed7895548479fb6bb156bac3
-    SHA512 6ef8e7ddf5baa2ad70aa65bb86e1627bcc0223bf6cae2a1fca9be2d524921321b881e62df654a137d916b9b7e068fd6c6250bb02bce473f95c50b3da53829617
+    REF 1de7bce0420933b9a5b7ab8913952e79b3cc0f06
+    SHA512 e1563f7bbbefe278119b532e3f13d01f85930a741f0bf36e70aa8cfa4859da4ca2bd2a30ff35c1c61a810f373132763296795b1ad8ba019d70590419f7a52642
     HEAD_REF main
     PATCHES
         add-msvc-support.patch

--- a/script/dependencies.py
+++ b/script/dependencies.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         ('Eigen3', 'https://gitlab.com/libeigen/eigen', '3.4.0', default_cmake_args),
         ('eve', 'https://github.com/jfalcou/eve', '39a07c77527ded5aa00468d7a7daec2c7ca6caad', default_cmake_args),
         ('fluky', 'https://github.com/foolnotion/fluky', 'bc7fd453f0cdf900b17b20bb6d22aff1b9dc6d98', default_cmake_args),
-        ('vstat', 'https://github.com/heal-research/vstat', 'dd174d0dcc4a9fe7d15e8667a2ccb69b3870ded7', default_cmake_args),
+        ('vstat', 'https://github.com/heal-research/vstat', '495dca7736cef3db37cf6a8efced065c4befdab1', default_cmake_args),
         ('FastFloat', 'https://github.com/fastfloat/fast_float', '50a80a73ab2ab256ba1c3bf86923ddd8b4202bc7', default_cmake_args + ['-DFASTFLOAT_TEST=OFF']),
         ('unordered_dense', 'https://github.com/martinus/unordered_dense', 'v4.8.1', default_cmake_args),
         ('cpp-sort', 'https://github.com/Morwenn/cpp-sort', 'v2.1.0', default_cmake_args + ['-DBUILD_TESTING=0']),

--- a/script/dependencies.py
+++ b/script/dependencies.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         ('ndsort', 'https://github.com/foolnotion/ndsort', 'bd3b323b8d4373287e8cf303bc6304b929bc8ab1', default_cmake_args + ['-DBUILD_EXAMPLES=OFF']),
         ('small_vector', 'https://github.com/gharveymn/small_vector', 'v0.10.2', default_cmake_args + ['-DGCH_SMALL_VECTOR_ENABLE_TESTS=OFF', '-DGCH_SMALL_VECTOR_ENABLE_BENCHMARKS=OFF']),
         ('pappus', 'https://github.com/heal-research/pappus', 'b67fc412090c0bac324f6a3f2bbf4e07089eb67f', default_cmake_args),
-        ('operon', 'https://github.com/heal-research/operon', '26e4c48f5c6573a3ed7895548479fb6bb156bac3', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
+        ('operon', 'https://github.com/heal-research/operon', '1de7bce0420933b9a5b7ab8913952e79b3cc0f06', default_cmake_args + ['--preset', operon_build_preset, '-DBUILD_CLI_PROGRAMS=OFF', '-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_POSITION_INDEPENDENT_CODE=ON']),
     ]
 
     total = len(dependencies)

--- a/source/evaluator.cpp
+++ b/source/evaluator.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/optional.h>
 
 #include <operon/optimizer/optimizer.hpp>
 #include <operon/optimizer/solvers/sgd.hpp>
@@ -243,21 +244,18 @@ void InitEval(nb::module_ &m)
     nb::class_<Operon::DiversityEvaluator, TEvaluatorBase>(m, "DiversityEvaluator")
         .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>());
 
+    nb::enum_<Operon::MultiEvaluator::AggregateType>(m, "AggregateType")
+        .value("Min", Operon::MultiEvaluator::AggregateType::Min)
+        .value("Max", Operon::MultiEvaluator::AggregateType::Max)
+        .value("Median", Operon::MultiEvaluator::AggregateType::Median)
+        .value("Mean", Operon::MultiEvaluator::AggregateType::Mean)
+        .value("HarmonicMean", Operon::MultiEvaluator::AggregateType::HarmonicMean)
+        .value("Sum", Operon::MultiEvaluator::AggregateType::Sum);
+
     nb::class_<Operon::MultiEvaluator, TEvaluatorBase>(m, "MultiEvaluator")
         .def(nb::init<Operon::Problem const*>(), nb::keep_alive<1, 2>())
-        .def("Add", &Operon::MultiEvaluator::Add, nb::keep_alive<1, 2>());
-
-    nb::enum_<Operon::AggregateEvaluator::AggregateType>(m, "AggregateType")
-        .value("Min", Operon::AggregateEvaluator::AggregateType::Min)
-        .value("Max", Operon::AggregateEvaluator::AggregateType::Max)
-        .value("Median", Operon::AggregateEvaluator::AggregateType::Median)
-        .value("Mean", Operon::AggregateEvaluator::AggregateType::Mean)
-        .value("HarmonicMean", Operon::AggregateEvaluator::AggregateType::HarmonicMean)
-        .value("Sum", Operon::AggregateEvaluator::AggregateType::Sum);
-
-    nb::class_<Operon::AggregateEvaluator, TEvaluatorBase>(m, "AggregateEvaluator")
-        .def(nb::init<TEvaluatorBase const*>(), nb::keep_alive<1, 2>())
-        .def_prop_rw("AggregateType", &Operon::AggregateEvaluator::GetAggregateType, &Operon::AggregateEvaluator::SetAggregateType);
+        .def("Add", &Operon::MultiEvaluator::Add, nb::keep_alive<1, 2>())
+        .def_prop_rw("AggregateType", &Operon::MultiEvaluator::GetAggregateType, &Operon::MultiEvaluator::SetAggregateType);
 
     nb::class_<detail::MDLEvaluator>(m, "MinimumDescriptionLengthEvaluator")
         .def(nb::init<Operon::Problem const&, TDispatch const&, std::string const&>(),

--- a/source/mutation.cpp
+++ b/source/mutation.cpp
@@ -68,7 +68,8 @@ void InitMutation(nb::module_ &m)
         .def("__call__", &Operon::ReplaceSubtreeMutation::operator());
 
     nb::class_<Operon::RemoveSubtreeMutation, Operon::MutatorBase>(m, "RemoveSubtreeMutation")
-        .def(nb::init<Operon::PrimitiveSet>())
+        .def(nb::init<Operon::CreatorBase const*, Operon::CoefficientInitializerBase const*, size_t>(),
+                nb::keep_alive<1, 2>(), nb::keep_alive<1, 3>())
         .def("__call__", &Operon::RemoveSubtreeMutation::operator());
 
     nb::class_<Operon::InsertSubtreeMutation, Operon::MutatorBase>(m, "InsertSubtreeMutation")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
         {
             "kind": "git",
             "repository": "https://github.com/foolnotion/vcpkg-registry",
-            "baseline": "ef66d57bf16d0f407c7e1cc0f86332f704d82426",
+            "baseline": "4e66c708fbe2988ef5455c169b21e6653eb55d1c",
             "packages": [
                 "aria-csv",
                 "asmjit",


### PR DESCRIPTION
Follows heal-research/operon#165 (merged), which folded `AggregateEvaluator` into `MultiEvaluator`: `MultiEvaluator` now takes an optional `AggregateType` and performs the aggregation itself, inheriting the `Prepare()` cascade to sub-evaluators for free. `AggregateEvaluator` is removed from operon's public API.

## Changes

- **`source/evaluator.cpp`** — drop the `AggregateEvaluator` binding; move the `AggregateType` enum under `MultiEvaluator` and expose it as a property on `MultiEvaluator` (get/set/clear via `std::optional`; from Python `me.AggregateType = None` clears). Add `<nanobind/stl/optional.h>`.
- **`source/mutation.cpp`** — update `RemoveSubtreeMutation` ctor to `(CreatorBase const*, CoefficientInitializerBase const*, size_t maxDepth)`, matching operon's new signature and the `ReplaceSubtreeMutation`/`InsertSubtreeMutation` siblings. Required by the operon pin bump.
- **`flake.lock` + `script/dependencies.py`** — bump operon pin to `1de7bce0` (includes operon #165 plus its nit-fix follow-up `MultiEvaluator: fix fit reservation + add ClearAggregateType`).

## Verification
- `nix build .#pyoperon-generic` — clean (evaluator.cpp.o + mutation.cpp.o compile, links, produces the .so).
- Runtime: `import pyoperon` succeeds; `AggregateType` enum exposed with all 6 members (`Min`/`Max`/`Median`/`Mean`/`HarmonicMean`/`Sum`); `AggregateEvaluator` no longer present; `MultiEvaluator.AggregateType` property reachable.
- No `pyoperon/*.py` changes needed (`sklearn.py` only ever used `MultiEvaluator` + `Add`, never `AggregateEvaluator`).