### PR TITLE
fix(ci): bootstrap vcpkg.exe after updating scripts on windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Update vcpkg
-        run: git -C C:/vcpkg fetch origin && git -C C:/vcpkg reset --hard origin/master
+        run: git -C C:/vcpkg fetch origin && git -C C:/vcpkg reset --hard origin/master && C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics
 
       - name: Cache vcpkg downloads
         uses: actions/cache@v4


### PR DESCRIPTION
## Problem
The Windows wheel builds started failing with, for every port:
```
C:\vcpkg\scripts\vcpkg-tools.json: error: (a tool data file):
  document schema version 2 is not supported by this version of vcpkg
error: while checking out baseline from commit 'd87340acc...',
  failed to `git show` versions/baseline.json.
```

## Root cause
`.github/workflows/build-windows.yml` updated the vcpkg **scripts** via `git -C C:/vcpkg fetch origin && git reset --hard origin/master`, but never re-bootstrapped the pre-installed `C:/vcpkg/vcpkg.exe`. The runner image ships an exe that lags behind `origin/master`; once vcpkg master bumped `scripts/vcpkg-tools.json` to schema version 2, the stale exe could no longer parse it and the toolchain cascaded into baseline-checkout errors. This is independent of any source change — it breaks any PR to pyoperon right now. (`vcpkg.json`'s `builtin-baseline` `d87340ac` is a valid, reachable vcpkg commit; it is not the problem.)

## Fix
Append `C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics` to the Update vcpkg step so the executable is rebuilt to match the freshly-pulled scripts.

## Scope
Only `build-windows.yml` is affected — the linux/macos workflows build via `script/dependencies.py`, not vcpkg.

## Verification
CI on this PR (the windows-wheels matrix) is the validation.